### PR TITLE
Update datetime checkValue method

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/DataType.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/DataType.scala
@@ -24,7 +24,7 @@ case object DateTime extends DataType with Product with Serializable {
       case "" if criteria.required  => Some(EMPTY_VALUE_ERROR)
       case "" if !criteria.required => None
       case v =>
-        val date = v.replaceAll("[T ]", "-").split("[-:]")
+        val date = v.replaceAll("[T ]", ":").split("[/:]")
         if (date.length < 6) {
           Some(INVALID_DATE_FORMAT_ERROR)
         } else {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/DataType.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/DataType.scala
@@ -24,7 +24,7 @@ case object DateTime extends DataType with Product with Serializable {
       case "" if criteria.required  => Some(EMPTY_VALUE_ERROR)
       case "" if !criteria.required => None
       case v =>
-        val date = v.replace("T", "-").split("[-:]")
+        val date = v.replaceAll("[T ]", "-").split("[-:]")
         if (date.length < 6) {
           Some(INVALID_DATE_FORMAT_ERROR)
         } else {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/DataTypeSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/DataTypeSpec.scala
@@ -32,9 +32,10 @@ class DataTypeSpec extends AnyWordSpec {
     val criteria = MetadataCriteria("Property1", DateTime, required = true, isFutureDateAllowed = false, isMultiValueAllowed = false, Nil, None, None)
 
     "checkValue should not return any errors if the date is valid" in {
-      DateTime.checkValue("1990-12-10T00:00:00", criteria) should be(None)
-      DateTime.checkValue("2000-2-29T00:00:00", criteria) should be(None)
-      DateTime.checkValue("1990-01-01 00:00:00.0", criteria) should be(None)
+      DateTime.checkValue("1990/12/10T00:00:00", criteria) should be(None)
+      DateTime.checkValue("2000/2/29T00:00:00", criteria) should be(None)
+      DateTime.checkValue("1990/01/01 00:00:00.0", criteria) should be(None)
+      DateTime.checkValue("1990:01:01T00:00:00.0", criteria) should be(None)
     }
 
     "checkValue should not return any errors if the value is empty but it is not mandatory" in {
@@ -42,47 +43,53 @@ class DataTypeSpec extends AnyWordSpec {
     }
 
     "checkValue should not return any errors if future date is allowed" in {
-      DateTime.checkValue("1990-12-10T00:00:00", criteria.copy(isFutureDateAllowed = true)) should be(None)
-      DateTime.checkValue("2090-12-10T00:00:00", criteria.copy(isFutureDateAllowed = true)) should be(None)
-      DateTime.checkValue("2090-12-10 00:00:00", criteria.copy(isFutureDateAllowed = true)) should be(None)
+      DateTime.checkValue("1990/12/10T00:00:00", criteria.copy(isFutureDateAllowed = true)) should be(None)
+      DateTime.checkValue("2090/12/10T00:00:00", criteria.copy(isFutureDateAllowed = true)) should be(None)
+      DateTime.checkValue("2090/12/10 00:00:00", criteria.copy(isFutureDateAllowed = true)) should be(None)
     }
 
     "checkValue should return an error if the date format is invalid" in {
-      DateTime.checkValue("1990/12/10T00:00:00", criteria) should be(Some(INVALID_DATE_FORMAT_ERROR))
-      DateTime.checkValue("2000-2-29", criteria) should be(Some(INVALID_DATE_FORMAT_ERROR))
+      DateTime.checkValue("1990-12-10T00:00:00", criteria) should be(Some(INVALID_DATE_FORMAT_ERROR))
+      DateTime.checkValue("2000/2/29", criteria) should be(Some(INVALID_DATE_FORMAT_ERROR))
+    }
+
+    "checkValue should return an error if the day/month/year in negative" in {
+      DateTime.checkValue("1990:12:-10T00:00:00", criteria) should be(Some(NEGATIVE_NUMBER_ERROR_FOR_DAY))
+      DateTime.checkValue("1990:-12:10T00:00:00", criteria) should be(Some(NEGATIVE_NUMBER_ERROR_FOR_MONTH))
+      DateTime.checkValue("-1990:12:10T00:00:00", criteria) should be(Some(NEGATIVE_NUMBER_ERROR_FOR_YEAR))
     }
 
     "checkValue should return an error if the value is empty and mandatory" in {
       DateTime.checkValue("", criteria) should be(Some(EMPTY_VALUE_ERROR))
-      DateTime.checkValue("--T00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR))
+      DateTime.checkValue("//T00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR))
     }
 
     "checkValue should return an error if the day or month or year is empty" in {
-      DateTime.checkValue("1990-10-T00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR_FOR_DAY))
-      DateTime.checkValue("1990--10T00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR_FOR_MONTH))
-      DateTime.checkValue("-10-10T00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR_FOR_YEAR))
-      DateTime.checkValue("-10-10 00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR_FOR_YEAR))
+      DateTime.checkValue("1990/10/T00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR_FOR_DAY))
+      DateTime.checkValue("1990//10T00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR_FOR_MONTH))
+      DateTime.checkValue("/10/10T00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR_FOR_YEAR))
+      DateTime.checkValue("/10/10 00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR_FOR_YEAR))
     }
 
     "checkValue should return an error if the day or month or year is not valid" in {
-      DateTime.checkValue("1990-10-32T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_DAY))
-      DateTime.checkValue("1990-28-10T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_MONTH))
-      DateTime.checkValue("19999-10-10T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_YEAR))
-      DateTime.checkValue("199-10-10T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_YEAR))
-      DateTime.checkValue("199-10-10 00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_YEAR))
+      DateTime.checkValue("1990/10/32T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_DAY))
+      DateTime.checkValue("1990/28/10T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_MONTH))
+      DateTime.checkValue("19999/10/10T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_YEAR))
+      DateTime.checkValue("199/10/10T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_YEAR))
+      DateTime.checkValue("199/10/10 00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_YEAR))
     }
 
     "checkValue should return an error if the day is not valid for given month" in {
-      DateTime.checkValue("1990-2-29T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
-      DateTime.checkValue("1990-4-31T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
-      DateTime.checkValue("1990-6-31T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
-      DateTime.checkValue("1990-9-31T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
-      DateTime.checkValue("1990-11-31T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
-      DateTime.checkValue("1990-11-31 00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
+      DateTime.checkValue("1990/2/29T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
+      DateTime.checkValue("1990/4/31T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
+      DateTime.checkValue("1990/6/31T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
+      DateTime.checkValue("1990/9/31T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
+      DateTime.checkValue("1990/11/31T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
+      DateTime.checkValue("1990/11/31 00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
     }
 
     "checkValue should return an error if future date is not allowed" in {
-      DateTime.checkValue("2050-2-1T00:00:00", criteria) should be(Some(FUTURE_DATE_ERROR))
+      DateTime.checkValue("2050/2/1T00:00:00", criteria) should be(Some(FUTURE_DATE_ERROR))
     }
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/DataTypeSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/DataTypeSpec.scala
@@ -34,6 +34,7 @@ class DataTypeSpec extends AnyWordSpec {
     "checkValue should not return any errors if the date is valid" in {
       DateTime.checkValue("1990-12-10T00:00:00", criteria) should be(None)
       DateTime.checkValue("2000-2-29T00:00:00", criteria) should be(None)
+      DateTime.checkValue("1990-01-01 00:00:00.0", criteria) should be(None)
     }
 
     "checkValue should not return any errors if the value is empty but it is not mandatory" in {
@@ -43,6 +44,7 @@ class DataTypeSpec extends AnyWordSpec {
     "checkValue should not return any errors if future date is allowed" in {
       DateTime.checkValue("1990-12-10T00:00:00", criteria.copy(isFutureDateAllowed = true)) should be(None)
       DateTime.checkValue("2090-12-10T00:00:00", criteria.copy(isFutureDateAllowed = true)) should be(None)
+      DateTime.checkValue("2090-12-10 00:00:00", criteria.copy(isFutureDateAllowed = true)) should be(None)
     }
 
     "checkValue should return an error if the date format is invalid" in {
@@ -59,6 +61,7 @@ class DataTypeSpec extends AnyWordSpec {
       DateTime.checkValue("1990-10-T00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR_FOR_DAY))
       DateTime.checkValue("1990--10T00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR_FOR_MONTH))
       DateTime.checkValue("-10-10T00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR_FOR_YEAR))
+      DateTime.checkValue("-10-10 00:00:00", criteria) should be(Some(EMPTY_VALUE_ERROR_FOR_YEAR))
     }
 
     "checkValue should return an error if the day or month or year is not valid" in {
@@ -66,6 +69,7 @@ class DataTypeSpec extends AnyWordSpec {
       DateTime.checkValue("1990-28-10T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_MONTH))
       DateTime.checkValue("19999-10-10T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_YEAR))
       DateTime.checkValue("199-10-10T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_YEAR))
+      DateTime.checkValue("199-10-10 00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_YEAR))
     }
 
     "checkValue should return an error if the day is not valid for given month" in {
@@ -74,6 +78,7 @@ class DataTypeSpec extends AnyWordSpec {
       DateTime.checkValue("1990-6-31T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
       DateTime.checkValue("1990-9-31T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
       DateTime.checkValue("1990-11-31T00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
+      DateTime.checkValue("1990-11-31 00:00:00", criteria) should be(Some(INVALID_DAY_FOR_MONTH_ERROR))
     }
 
     "checkValue should return an error if future date is not allowed" in {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationSpec.scala
@@ -20,7 +20,7 @@ class MetadataValidationSpec extends AnyFlatSpec {
       Metadata("ClosureType", "Closed"),
       Metadata("Property1", "yes"),
       Metadata("Property2", "hello"),
-      Metadata("Property3", "1990-10-10T00:00:00"),
+      Metadata("Property3", "1990/10/10T00:00:00"),
       Metadata("Property4", "90")
     )
     val metadataValidation = new MetadataValidation(closureMetadataCriteria, Nil)
@@ -104,7 +104,7 @@ class MetadataValidationSpec extends AnyFlatSpec {
       Metadata("ClosureType", "Closed"),
       Metadata("Property1", ""),
       Metadata("Property2", ""),
-      Metadata("Property3", "1990-55-10T00:00:00"),
+      Metadata("Property3", "1990/55/10T00:00:00"),
       Metadata("Property4", "tt")
     )
     val metadataValidation = new MetadataValidation(closureMetadataCriteria, Nil)


### PR DESCRIPTION
Update datetime checkValue method to validate if the datetime is without 'T' letter ("1990-12-1 00.00.00.0")
Use a slash ('/') instead of '-' to separate day, month and year so that it can validate a negative number if the user passes via HTML form