### PR TITLE
TDR 3342: Align metadata validation library with validation logic and field precedence in `tdr-transfer-frontend`

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/DataType.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/DataType.scala
@@ -3,7 +3,7 @@ package uk.gov.nationalarchives.tdr.validation
 import uk.gov.nationalarchives.tdr.validation.ErrorCode._
 
 import java.sql.Timestamp
-import java.time.{LocalDateTime, Year, YearMonth}
+import java.time.{LocalDateTime, YearMonth}
 import scala.util.control.Exception.allCatch
 
 sealed trait DataType

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/DataTypeSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/DataTypeSpec.scala
@@ -96,6 +96,12 @@ class DataTypeSpec extends AnyWordSpec {
     "checkValue should return an error if future date is not allowed" in {
       DateTime.checkValue("2050/2/1T00:00:00", criteria) should be(Some(FUTURE_DATE_ERROR))
     }
+
+    "checkValue should return errors in year, month, day precedence" in {
+      DateTime.checkValue("19900/35/35T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_YEAR))
+      DateTime.checkValue("1990/35/35T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_MONTH))
+      DateTime.checkValue("1990/12/35T00:00:00", criteria) should be(Some(INVALID_NUMBER_ERROR_FOR_DAY))
+    }
   }
 
   "Text" should {


### PR DESCRIPTION
In https://github.com/nationalarchives/tdr-transfer-frontend/pull/3588, we construct a full error message with the allowable range for the given month and year whenever the day entered is larger than the total number of days in the month. We therefore need to return year/month errors in precedence to day errors as validated years and months are required to construct the day error message. 

We currently have the logic for selecting error codes and building error messages in two different places- will probably want to consolidate these into one at some point.