### PR TITLE
Pass in multiple schemas validation

### DIFF
--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -5,104 +5,170 @@ import org.apache.pekko.testkit.{ImplicitSender, TestKit}
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpecLike
 import uk.gov.nationalarchives.tdr.validation.schema.JsonSchemaDefinition.{BASE_SCHEMA, CLOSURE_SCHEMA}
-import uk.gov.nationalarchives.tdr.validation.schema.MetadataValidationJsonSchema
+import uk.gov.nationalarchives.tdr.validation.schema.{JsonSchemaDefinition, MetadataValidationJsonSchema}
 import uk.gov.nationalarchives.tdr.validation.schema.MetadataValidationJsonSchema.ObjectMetadata
 
 class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataValidationJsonSchemaSpec")) with ImplicitSender with AnyWordSpecLike {
 
+  "MetadataValidationJsonSchema multiple schema" should {
+    val schemaDefinitions: Set[JsonSchemaDefinition] = Set(BASE_SCHEMA, CLOSURE_SCHEMA)
+    "validate data against all schema and return no errors if data valid" in {
+      val data: Set[ObjectMetadata] =
+        Set(ObjectMetadata("file1", Set(Metadata("closure_type", "Open")))) ++ dataBuilder("Language", "Welsh")
+      val validationResults = MetadataValidationJsonSchema.validate(schemaDefinitions, data)
+      validationResults.size shouldBe 2
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
+      validationResults.head.schemaErrors.head._2.size shouldBe 0
+      validationResults.last.schemaLocation shouldBe CLOSURE_SCHEMA.location
+      validationResults.last.schemaErrors.head._2.size shouldBe 0
+    }
+
+    "validate data against all schema and return expected errors if data invalid" in {
+      val data: Set[ObjectMetadata] =
+        Set(
+          ObjectMetadata(
+            "file1",
+            Set(
+              Metadata("closure_type", "Closed"),
+              Metadata("Language", "Unknown")
+            )
+          )
+        )
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA, CLOSURE_SCHEMA), data)
+      validationResults.size shouldBe 2
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
+      validationResults.head.schemaErrors.head._2.size shouldBe 1
+      validationResults.last.schemaLocation shouldBe CLOSURE_SCHEMA.location
+      validationResults.last.schemaErrors.head._2.size shouldBe 6
+    }
+  }
+
   "MetadataValidationJsonSchema BASIC_SCHEMA" should {
     "validate incorrect value in enumerated array" in {
       val data: Set[ObjectMetadata] = dataBuilder("Language", "Unknown")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "language", "enum")
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      singleErrorCheck(validationResults.head.schemaErrors, "language", "enum")
     }
     "validate correct value enumerated array" in {
       val data: Set[ObjectMetadata] = dataBuilder("Language", "Welsh")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 0
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate array can be null" in {
       val data: Set[ObjectMetadata] = dataBuilder("Language", "")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 0
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate incorrect date format" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "12-12-2012")
-      val validationErrors: Map[String, List[Error]] = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "date_last_modified", "format.date")
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 1
+      singleErrorCheck(validationResults.head.schemaErrors, "date_last_modified", "format.date")
     }
     "validate correct date format" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "2023-12-05")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 0
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate date last modified must have a value" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "date_last_modified", "type")
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 1
+      singleErrorCheck(validationResults.head.schemaErrors, "date_last_modified", "type")
     }
     "validate end date can be empty" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date of the record", "")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 0
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate end date must be before today" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date of the record", "3000-12-12")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "end_date", "daBeforeToday")
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 1
+      singleErrorCheck(validationResults.head.schemaErrors, "end_date", "daBeforeToday")
     }
     "validate closure period must be a number" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "123")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 0
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate closure period must be less than 150" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "151")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "closure_period", "maximum")
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 1
+      singleErrorCheck(validationResults.head.schemaErrors, "closure_period", "maximum")
     }
     "validate closure period must be at least 1" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "0")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "closure_period", "minimum")
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 1
+      singleErrorCheck(validationResults.head.schemaErrors, "closure_period", "minimum")
     }
     "validate closure period can be 150" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "150")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 0
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate closure period can be 1" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "1")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 0
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate title closed is a boolean" in {
       val data: Set[ObjectMetadata] = dataBuilder("Is the title sensitive for the public?", "Yes")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 0
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate title closed not yes/no" in {
       val data: Set[ObjectMetadata] = dataBuilder("Is the title sensitive for the public?", "blah")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "title_closed", "unionType")
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 1
+      singleErrorCheck(validationResults.head.schemaErrors, "title_closed", "unionType")
     }
     "validate file path ok with one character" in {
       val data: Set[ObjectMetadata] = dataBuilder("Filepath", "b")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 0
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate file path must have content" in {
       val data: Set[ObjectMetadata] = dataBuilder("Filepath", "")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "file_path", "type")
+      val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 1
+      singleErrorCheck(validationResults.head.schemaErrors, "file_path", "type")
     }
   }
 
@@ -110,22 +176,28 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
 
     "not return any errors when closure_type is Open" in {
       val data: Set[ObjectMetadata] = Set(ObjectMetadata("file1", Set(Metadata("closure_type", "Open"))))
-      val validationErrors = MetadataValidationJsonSchema.validate(CLOSURE_SCHEMA, data)
-      validationErrors("file1") shouldBe List.empty
+      val validationResults = MetadataValidationJsonSchema.validate(Set(CLOSURE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/closureSchema.schema.json"
+      validationResults.head.schemaErrors("file1") shouldBe List.empty
     }
 
     "not return any errors when closure_type is Closed" in {
       val data: Set[ObjectMetadata] = closureDataBuilder("1990-01-12", "33", "12", "1990-11-12", "No", "No")
-      val validationErrors = MetadataValidationJsonSchema.validate(CLOSURE_SCHEMA, data)
-      validationErrors("file1") shouldBe List.empty
+      val validationResults = MetadataValidationJsonSchema.validate(Set(CLOSURE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/closureSchema.schema.json"
+      validationResults.head.schemaErrors("file1") shouldBe List.empty
     }
 
     "return errors with all the required fields when closure_type is Closed" in {
       val closure = Metadata("closure_type", "Closed")
       val data: Set[ObjectMetadata] = Set(ObjectMetadata("file1", Set(closure)))
-      val validationErrors = MetadataValidationJsonSchema.validate(CLOSURE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 6
-      validationErrors("file1") should contain theSameElementsAs List(
+      val validationResults = MetadataValidationJsonSchema.validate(Set(CLOSURE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/closureSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 6
+      validationResults.head.schemaErrors("file1") should contain theSameElementsAs List(
         Error("closure_start_date", "required"),
         Error("foi_exemption_code", "required"),
         Error("closure_period", "required"),
@@ -137,9 +209,11 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
 
     "return errors if required fields has invalid values when closure_type is Closed" in {
       val data: Set[ObjectMetadata] = closureDataBuilder("1990--12", "55", "-12", "1990--12", "tttt", "tttt")
-      val validationErrors = MetadataValidationJsonSchema.validate(CLOSURE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 6
-      validationErrors("file1") should contain theSameElementsAs List(
+      val validationResults = MetadataValidationJsonSchema.validate(Set(CLOSURE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/closureSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 6
+      validationResults.head.schemaErrors("file1") should contain theSameElementsAs List(
         Error("closure_start_date", "format.date"),
         Error("foi_exemption_code", "enum"),
         Error("closure_period", "minimum"),
@@ -151,9 +225,11 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
 
     "return errors if required fields have empty values when closure_type is Closed" in {
       val data: Set[ObjectMetadata] = closureDataBuilder("", "", "", "", "", "")
-      val validationErrors = MetadataValidationJsonSchema.validate(CLOSURE_SCHEMA, data)
-      validationErrors("file1").size shouldBe 6
-      validationErrors("file1") should contain theSameElementsAs List(
+      val validationResults = MetadataValidationJsonSchema.validate(Set(CLOSURE_SCHEMA), data)
+      validationResults.size shouldBe 1
+      validationResults.head.schemaLocation shouldBe "/metadata-schema/closureSchema.schema.json"
+      validationResults.head.schemaErrors("file1").size shouldBe 6
+      validationResults.head.schemaErrors("file1") should contain theSameElementsAs List(
         Error("closure_start_date", "type"),
         Error("foi_exemption_code", "type"),
         Error("closure_period", "type"),

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -43,7 +43,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
     }
   }
 
-  "MetadataValidationJsonSchema BASIC_SCHEMA" should {
+  "MetadataValidationJsonSchema BASE_SCHEMA" should {
     "validate incorrect value in enumerated array" in {
       val data: Set[ObjectMetadata] = dataBuilder("Language", "Unknown")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -48,28 +48,28 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Language", "Unknown")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       singleErrorCheck(validationResults.head.schemaErrors, "language", "enum")
     }
     "validate correct value enumerated array" in {
       val data: Set[ObjectMetadata] = dataBuilder("Language", "Welsh")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate array can be null" in {
       val data: Set[ObjectMetadata] = dataBuilder("Language", "")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate incorrect date format" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "12-12-2012")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 1
       singleErrorCheck(validationResults.head.schemaErrors, "date_last_modified", "format.date")
     }
@@ -77,14 +77,14 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "2023-12-05")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate date last modified must have a value" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 1
       singleErrorCheck(validationResults.head.schemaErrors, "date_last_modified", "type")
     }
@@ -92,14 +92,14 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Date of the record", "")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate end date must be before today" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date of the record", "3000-12-12")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 1
       singleErrorCheck(validationResults.head.schemaErrors, "end_date", "daBeforeToday")
     }
@@ -107,14 +107,14 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "123")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate closure period must be less than 150" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "151")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 1
       singleErrorCheck(validationResults.head.schemaErrors, "closure_period", "maximum")
     }
@@ -122,7 +122,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "0")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 1
       singleErrorCheck(validationResults.head.schemaErrors, "closure_period", "minimum")
     }
@@ -130,28 +130,28 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "150")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate closure period can be 1" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "1")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate title closed is a boolean" in {
       val data: Set[ObjectMetadata] = dataBuilder("Is the title sensitive for the public?", "Yes")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate title closed not yes/no" in {
       val data: Set[ObjectMetadata] = dataBuilder("Is the title sensitive for the public?", "blah")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 1
       singleErrorCheck(validationResults.head.schemaErrors, "title_closed", "unionType")
     }
@@ -159,14 +159,14 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Filepath", "b")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 0
     }
     "validate file path must have content" in {
       val data: Set[ObjectMetadata] = dataBuilder("Filepath", "")
       val validationResults = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/baseSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe BASE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 1
       singleErrorCheck(validationResults.head.schemaErrors, "file_path", "type")
     }
@@ -178,7 +178,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = Set(ObjectMetadata("file1", Set(Metadata("closure_type", "Open"))))
       val validationResults = MetadataValidationJsonSchema.validate(Set(CLOSURE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/closureSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe CLOSURE_SCHEMA.location
       validationResults.head.schemaErrors("file1") shouldBe List.empty
     }
 
@@ -186,7 +186,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = closureDataBuilder("1990-01-12", "33", "12", "1990-11-12", "No", "No")
       val validationResults = MetadataValidationJsonSchema.validate(Set(CLOSURE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/closureSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe CLOSURE_SCHEMA.location
       validationResults.head.schemaErrors("file1") shouldBe List.empty
     }
 
@@ -195,7 +195,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = Set(ObjectMetadata("file1", Set(closure)))
       val validationResults = MetadataValidationJsonSchema.validate(Set(CLOSURE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/closureSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe CLOSURE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 6
       validationResults.head.schemaErrors("file1") should contain theSameElementsAs List(
         Error("closure_start_date", "required"),
@@ -211,7 +211,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = closureDataBuilder("1990--12", "55", "-12", "1990--12", "tttt", "tttt")
       val validationResults = MetadataValidationJsonSchema.validate(Set(CLOSURE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/closureSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe CLOSURE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 6
       validationResults.head.schemaErrors("file1") should contain theSameElementsAs List(
         Error("closure_start_date", "format.date"),
@@ -227,7 +227,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = closureDataBuilder("", "", "", "", "", "")
       val validationResults = MetadataValidationJsonSchema.validate(Set(CLOSURE_SCHEMA), data)
       validationResults.size shouldBe 1
-      validationResults.head.schemaLocation shouldBe "/metadata-schema/closureSchema.schema.json"
+      validationResults.head.schemaLocation shouldBe CLOSURE_SCHEMA.location
       validationResults.head.schemaErrors("file1").size shouldBe 6
       validationResults.head.schemaErrors("file1") should contain theSameElementsAs List(
         Error("closure_start_date", "type"),

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/utils/CSVtoJsonUtilsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/utils/CSVtoJsonUtilsSpec.scala
@@ -10,56 +10,56 @@ class CSVtoJsonUtilsSpec extends AnyWordSpec {
     "correctly convert a numeric string to a JSON `number`" in {
       val utils = new CSVtoJsonUtils()
       val testData = Map("Closure Period" -> "5")
-      val result = utils.convertToJSONString(testData)
+      val result = utils.convertToJSONString(testData, "tdrFileHeader")
       assert(result == """{"closure_period":5}""")
     }
 
     "return a JSON string when the input is not a `number`" in {
       val utils = new CSVtoJsonUtils()
       val testData = Map("Closure Period" -> "abc")
-      val result = utils.convertToJSONString(testData)
+      val result = utils.convertToJSONString(testData, "tdrFileHeader")
       assert(result == """{"closure_period":"abc"}""")
     }
 
     "correctly convert a split an array string to a JSON `array`" in {
       val utils = new CSVtoJsonUtils()
       val testData = Map("FOI exemption code" -> "37(1)(ab)|44")
-      val result = utils.convertToJSONString(testData)
+      val result = utils.convertToJSONString(testData, "tdrFileHeader")
       assert(result == """{"foi_exemption_code":["37(1)(ab)","44"]}""")
     }
 
     "return a JSON string when the input array cannot be split" in {
       val utils = new CSVtoJsonUtils()
       val testData = Map("FOI exemption code" -> "37(1)(ab)+44")
-      val result = utils.convertToJSONString(testData)
+      val result = utils.convertToJSONString(testData, "tdrFileHeader")
       assert(result == """{"foi_exemption_code":["37(1)(ab)+44"]}""")
     }
 
     "return a empty JSON string when the input array is empty" in {
       val utils = new CSVtoJsonUtils()
       val testData = Map("Language" -> "")
-      val result = utils.convertToJSONString(testData)
+      val result = utils.convertToJSONString(testData, "tdrFileHeader")
       assert(result == """{"language":""}""")
     }
 
     "correctly convert a boolean string to a JSON `boolean`" in {
       val utils = new CSVtoJsonUtils()
       val testData = Map("Is the title sensitive for the public?" -> "Yes", "Is the description sensitive for the public?" -> "No")
-      val result = utils.convertToJSONString(testData)
+      val result = utils.convertToJSONString(testData, "tdrFileHeader")
       assert(result == """{"title_closed":true,"description_closed":false}""")
     }
 
     "return a JSON string when the input boolean cannot be converted" in {
       val utils = new CSVtoJsonUtils()
       val testData = Map("Is the title sensitive for the public?" -> "y", "Is the description sensitive for the public?" -> "n")
-      val result = utils.convertToJSONString(testData)
+      val result = utils.convertToJSONString(testData, "tdrFileHeader")
       assert(result == """{"title_closed":"y","description_closed":"n"}""")
     }
 
     "Preserve key-value pairs when key is not in schema" in {
       val utils = new CSVtoJsonUtils()
       val testData = Map("unknown" -> "some value")
-      val result = utils.convertToJSONString(testData)
+      val result = utils.convertToJSONString(testData, "tdrFileHeader")
       assert(result == """{"unknown":"some value"}""")
     }
   }


### PR DESCRIPTION
Allow clients to validate data against multiple schemas

Provide results categorised by the individual schema definition to support client's handling errors in different way depending on the schema

This will support SharePoint functionality where both system and additional metadata will be loaded and validated