### PR TITLE
Change 'fileName' parameter name

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidation.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidation.scala
@@ -4,13 +4,13 @@ import org.apache.commons.lang3.BooleanUtils
 import uk.gov.nationalarchives.tdr.validation.ErrorCode._
 import uk.gov.nationalarchives.tdr.validation.MetadataProperty._
 
-case class FileRow(fileName: String, metadata: List[Metadata])
+case class FileRow(matchIdentifier: String, metadata: List[Metadata])
 case class Error(propertyName: String, errorCode: String)
 
 class MetadataValidation(closureMetadataCriteria: MetadataCriteria, descriptiveMetadataCriteria: List[MetadataCriteria]) extends scala.Serializable {
 
   def validateMetadata(fileRows: List[FileRow]): Map[String, List[Error]] = {
-    fileRows.map(row => row.fileName -> (validateClosureMetadata(row.metadata) ++ validateDescriptiveMetadata(row.metadata))).toMap
+    fileRows.map(row => row.matchIdentifier -> (validateClosureMetadata(row.metadata) ++ validateDescriptiveMetadata(row.metadata))).toMap
   }
 
   def validateClosureMetadata(input: List[Metadata]): List[Error] = {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
@@ -20,7 +20,7 @@ object MetadataValidationJsonSchema {
 
   // Interface for draft metadata validator
   def validate(metadata: List[FileRow]): Map[String, List[Error]] = {
-    val convertedFileRows: Seq[ObjectMetadata] = metadata.map(fileRow => ObjectMetadata(fileRow.fileName, fileRow.metadata.toSet))
+    val convertedFileRows: Seq[ObjectMetadata] = metadata.map(fileRow => ObjectMetadata(fileRow.matchIdentifier, fileRow.metadata.toSet))
     val validationProgram = for {
       jsonData <- IO(convertedFileRows.map(objectMetadata => mapToJson(objectMetadata)))
       validationErrors <- IO(jsonData.map(jsonData => validateWithSchema(BASE_SCHEMA)(jsonData)))


### PR DESCRIPTION
Different sources of metadata will use different 'matchers' to match the metadata to the record in the database.

For example SharePoint metadata may use a UUID whilst user uploaded metadata may use the file name

To account for this use an agnotic name for the field that is used to match the row in the CSV to the record in the database