### PR TITLE
Return orignal header names in errors

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,19 +1,18 @@
 import sbt._
 
 object Dependencies {
-  private val pekkoVersion = "1.0.2"
+  private val pekkoVersion = "1.0.3"
 
   lazy val commonsLang3 = "org.apache.commons" % "commons-lang3" % "3.14.0"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19"
   lazy val ujson = "com.lihaoyi" % "ujson_native0.5_2.13" % "3.3.1"
-  lazy val jacksonModule = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.17.1"
-  lazy val metadataSchema = "uk.gov.nationalarchives" % "da-metadata-schema_3" % "0.0.23"
-  lazy val jsonSchemaValidator = "com.networknt" % "json-schema-validator" % "1.4.3"
+  lazy val jacksonModule = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.17.2"
+  lazy val metadataSchema = "uk.gov.nationalarchives" % "da-metadata-schema_3" % "0.0.25"
+  lazy val jsonSchemaValidator = "com.networknt" % "json-schema-validator" % "1.5.0"
   lazy val pekkoActor = "org.apache.pekko" %% "pekko-actor-typed" % pekkoVersion
   lazy val pekkoConnectors = "org.apache.pekko" %% "pekko-connectors-csv" % pekkoVersion
   lazy val pekkoStream = "org.apache.pekko" %% "pekko-stream" % pekkoVersion
   lazy val pekkoTestKit = "org.apache.pekko" %% "pekko-testkit" % pekkoVersion
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.5.4"
   lazy val nscalaTime = "com.github.nscala-time" %% "nscala-time" % "2.32.0"
-
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
@@ -18,14 +18,16 @@ object MetadataValidationJsonSchema {
 
   private val csvToJsonUtils = new CSVtoJsonUtils
 
+  private val defaultAlternativeHeaderKey = "tdrFileHeader"
+
   // Interface for draft metadata validator
   def validate(metadata: List[FileRow]): Map[String, List[Error]] = {
     val convertedFileRows: Seq[ObjectMetadata] = metadata.map(fileRow => ObjectMetadata(fileRow.fileName, fileRow.metadata.toSet))
     val validationProgram = for {
-      jsonData <- IO(convertedFileRows.map(objectMetadata => mapToJson(objectMetadata)))
+      jsonData <- IO(convertedFileRows.map(objectMetadata => mapToJson(Some(defaultAlternativeHeaderKey))(objectMetadata)))
       validationErrors <- IO(jsonData.map(jsonData => validateWithSchema(BASE_SCHEMA)(jsonData)))
       closureValidationErrors <- IO(jsonData.map(jsonData => validateWithSchema(CLOSURE_SCHEMA)(jsonData)))
-      errors <- convertSchemaValidatorError(validationErrors ++ closureValidationErrors)
+      errors <- convertSchemaValidatorError(validationErrors ++ closureValidationErrors, None)
     } yield errors.toMap
 
     validationProgram.unsafeRunSync()
@@ -34,11 +36,15 @@ object MetadataValidationJsonSchema {
   /*
    Validate against specified schema
    */
-  def validate(schemaDefinition: JsonSchemaDefinition, metadata: Set[ObjectMetadata]): Map[String, List[Error]] = {
+  def validate(schemaDefinition: JsonSchemaDefinition, metadata: Set[ObjectMetadata], alternativeHeaderKey: Option[String]): Map[String, List[Error]] = {
     val validationProgram = for {
-      jsonData <- IO(metadata.map(objectMetadata => mapToJson(objectMetadata)))
+      jsonData <- IO(metadata.map(objectMetadata => mapToJson(alternativeHeaderKey)(objectMetadata)))
       validationErrors <- IO(jsonData.map(jsonData => validateWithSchema(schemaDefinition)(jsonData)))
-      errors <- convertSchemaValidatorError(validationErrors.toSeq)
+      headersMapping = alternativeHeaderKey match {
+        case Some(key) => Some(csvToJsonUtils.propertyNameToAlternativeKeyMapping(key))
+        case _         => None
+      }
+      errors <- convertSchemaValidatorError(validationErrors.toSeq, headersMapping)
     } yield errors.toMap
 
     validationProgram.unsafeRunSync()
@@ -58,16 +64,24 @@ object MetadataValidationJsonSchema {
   /*
    What we want to use for the errors has yet to be defined
    */
-  private def convertSchemaValidatorError(errors: Seq[MetadataValidationJsonSchema.ValidationErrors]): IO[Seq[(String, List[Error])]] = {
-    IO(errors.map(error => error.identifier -> error.errors.map(convertValidationMessageToError).toList))
+  private def convertSchemaValidatorError(
+      errors: Seq[MetadataValidationJsonSchema.ValidationErrors],
+      headersMapping: Option[Map[String, String]]
+  ): IO[Seq[(String, List[Error])]] = {
+    IO(errors.map(error => error.identifier -> error.errors.map(convertValidationMessageToError(_, headersMapping)).toList))
   }
 
-  private def convertValidationMessageToError(message: ValidationMessage): Error = {
-    Error(Option(message.getProperty).getOrElse(message.getInstanceLocation.getName(0)), message.getMessageKey)
+  private def convertValidationMessageToError(message: ValidationMessage, headersMapping: Option[Map[String, String]]): Error = {
+    val messagePropertyName = Option(message.getProperty).getOrElse(message.getInstanceLocation.getName(0))
+    val propertyName = headersMapping match {
+      case Some(mapping) => mapping.getOrElse(messagePropertyName, messagePropertyName)
+      case _             => messagePropertyName
+    }
+    Error(propertyName, message.getMessageKey)
   }
 
-  private def mapToJson: ObjectMetadata => JsonData = (data: ObjectMetadata) => {
+  private def mapToJson(alternativeKey: Option[String]): ObjectMetadata => JsonData = (data: ObjectMetadata) => {
     val mapData = data.metadata.foldLeft(Map.empty[String, String])((acc, metadata) => acc + (metadata.name -> metadata.value))
-    JsonData(data.identifier, csvToJsonUtils.convertToJSONString(mapData).replaceAll("\"\"", "null"))
+    JsonData(data.identifier, csvToJsonUtils.convertToJSONString(mapData, alternativeKey).replaceAll("\"\"", "null"))
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/utils/CSVtoJsonUtilsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/utils/CSVtoJsonUtilsSpec.scala
@@ -7,59 +7,100 @@ class CSVtoJsonUtilsSpec extends AnyWordSpec {
 
   "CSVtoJsonUtils" should {
 
+    "return mapping between Base Schema property and alternative header" in {
+      val utils = new CSVtoJsonUtils()
+      val mapping = utils.propertyNameToAlternativeKeyMapping("tdrFileHeader")
+
+      mapping.size shouldBe 18
+      mapping should contain theSameElementsAs Map(
+        "title_alternate" -> "Add alternative title without the file extension",
+        "closure_type" -> "Closure status",
+        "description" -> "Description",
+        "UUID" -> "UUID",
+        "former_reference_department" -> "Former reference",
+        "closure_period" -> "Closure Period",
+        "language" -> "Language",
+        "end_date" -> "Date of the record",
+        "file_path" -> "Filepath",
+        "foi_exemption_code" -> "FOI exemption code",
+        "closure_start_date" -> "Closure Start Date",
+        "file_name_translation" -> "Translated title of record",
+        "description_closed" -> "Is the description sensitive for the public?",
+        "title_closed" -> "Is the title sensitive for the public?",
+        "foi_exemption_asserted" -> "FOI decision asserted",
+        "date_last_modified" -> "Date last modified",
+        "description_alternate" -> "Alternative description",
+        "file_name" -> "Filename"
+      )
+    }
+
+    "return original property name when no alternative key provided" in {
+      val utils = new CSVtoJsonUtils()
+      val testData = Map("Closure Period" -> "5")
+      val result = utils.convertToJSONString(testData, None)
+      assert(result == """{"Closure Period":"5"}""")
+    }
+
+    "return base schema property name when alternative key provided" in {
+      val utils = new CSVtoJsonUtils()
+      val testData = Map("Closure Period" -> "5")
+      val result = utils.convertToJSONString(testData, Some("tdrFileHeader"))
+      assert(result == """{"closure_period":5}""")
+    }
+
     "correctly convert a numeric string to a JSON `number`" in {
       val utils = new CSVtoJsonUtils()
       val testData = Map("Closure Period" -> "5")
-      val result = utils.convertToJSONString(testData)
+      val result = utils.convertToJSONString(testData, Some("tdrFileHeader"))
       assert(result == """{"closure_period":5}""")
     }
 
     "return a JSON string when the input is not a `number`" in {
       val utils = new CSVtoJsonUtils()
-      val testData = Map("Closure Period" -> "abc")
-      val result = utils.convertToJSONString(testData)
+      val testData = Map("closure_period" -> "abc")
+      val result = utils.convertToJSONString(testData, None)
       assert(result == """{"closure_period":"abc"}""")
     }
 
     "correctly convert a split an array string to a JSON `array`" in {
       val utils = new CSVtoJsonUtils()
-      val testData = Map("FOI exemption code" -> "37(1)(ab)|44")
-      val result = utils.convertToJSONString(testData)
+      val testData = Map("foi_exemption_code" -> "37(1)(ab)|44")
+      val result = utils.convertToJSONString(testData, None)
       assert(result == """{"foi_exemption_code":["37(1)(ab)","44"]}""")
     }
 
     "return a JSON string when the input array cannot be split" in {
       val utils = new CSVtoJsonUtils()
-      val testData = Map("FOI exemption code" -> "37(1)(ab)+44")
-      val result = utils.convertToJSONString(testData)
+      val testData = Map("foi_exemption_code" -> "37(1)(ab)+44")
+      val result = utils.convertToJSONString(testData, None)
       assert(result == """{"foi_exemption_code":["37(1)(ab)+44"]}""")
     }
 
     "return a empty JSON string when the input array is empty" in {
       val utils = new CSVtoJsonUtils()
-      val testData = Map("Language" -> "")
-      val result = utils.convertToJSONString(testData)
+      val testData = Map("language" -> "")
+      val result = utils.convertToJSONString(testData, None)
       assert(result == """{"language":""}""")
     }
 
     "correctly convert a boolean string to a JSON `boolean`" in {
       val utils = new CSVtoJsonUtils()
-      val testData = Map("Is the title sensitive for the public?" -> "Yes", "Is the description sensitive for the public?" -> "No")
-      val result = utils.convertToJSONString(testData)
+      val testData = Map("title_closed" -> "Yes", "description_closed" -> "No")
+      val result = utils.convertToJSONString(testData, None)
       assert(result == """{"title_closed":true,"description_closed":false}""")
     }
 
     "return a JSON string when the input boolean cannot be converted" in {
       val utils = new CSVtoJsonUtils()
-      val testData = Map("Is the title sensitive for the public?" -> "y", "Is the description sensitive for the public?" -> "n")
-      val result = utils.convertToJSONString(testData)
+      val testData = Map("title_closed" -> "y", "description_closed" -> "n")
+      val result = utils.convertToJSONString(testData, None)
       assert(result == """{"title_closed":"y","description_closed":"n"}""")
     }
 
     "Preserve key-value pairs when key is not in schema" in {
       val utils = new CSVtoJsonUtils()
       val testData = Map("unknown" -> "some value")
-      val result = utils.convertToJSONString(testData)
+      val result = utils.convertToJSONString(testData, None)
       assert(result == """{"unknown":"some value"}""")
     }
   }


### PR DESCRIPTION
Currently the validation errors are returned using the BASE schema property names

Current flow:
--> alternative header --> convert header to BASE schema property name --> run validation      --> errors with BASE schema property name
--> 'Date last modified -> 'date_last_modifed'                         --> 'date_last_modified' -> 'date_last_modified'

This flow is confusing to any calling clients as data is returned in a form that was not inputted originally. It poses problems where the client relies on the alternative property for further processing, necessitating further transforms to data by the calling client

Refactor returns the orginally provided headers in the errors:
--> alternative header --> convert header to BASE schema property name --> run validation     --> convert errors to use alternative header
--> 'Date last modified -> 'date_last_modified'                        --> 'date_last_modified -> 'Date last modified'

A utils method is provided to give the mapping between the BASE schema property name and any alternative key