### PR TITLE
Tdrd 317 metadata validation errors error key

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/JsonSchemaDefinition.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/JsonSchemaDefinition.scala
@@ -1,8 +1,10 @@
 package uk.gov.nationalarchives.tdr.validation.schema
 
-sealed abstract class JsonSchemaDefinition(val location: String)
+import uk.gov.nationalarchives.tdr.validation.schema.ValidationProcess.{SCHEMA_BASE, SCHEMA_CLOSURE, ValidationProcess}
+
+sealed abstract class JsonSchemaDefinition(val schemaLocation: String, val validationProcess: ValidationProcess)
 
 object JsonSchemaDefinition {
-  final case object BASE_SCHEMA extends JsonSchemaDefinition("/metadata-schema/baseSchema.schema.json")
-  final case object CLOSURE_SCHEMA extends JsonSchemaDefinition("/metadata-schema/closureSchema.schema.json")
+  final case object BASE_SCHEMA extends JsonSchemaDefinition("/metadata-schema/baseSchema.schema.json", SCHEMA_BASE)
+  final case object CLOSURE_SCHEMA extends JsonSchemaDefinition("/metadata-schema/closureSchema.schema.json", SCHEMA_CLOSURE)
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/JsonSchemaValidators.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/JsonSchemaValidators.scala
@@ -18,13 +18,13 @@ object JsonSchemaValidators {
   }
 
   private def getJsonSchema(jsonSchemaDefinition: JsonSchemaDefinition, customSchemaKeywords: Map[String, Keyword] = Map.empty): JsonSchema = {
-    val schemaInputStream = getClass.getResourceAsStream(jsonSchemaDefinition.location)
+    val schemaInputStream = getClass.getResourceAsStream(jsonSchemaDefinition.schemaLocation)
     val schema = JsonMetaSchema.getV202012
 
     schema.getKeywords.putAll(customSchemaKeywords.asJava)
     val jsonSchemaFactory = new JsonSchemaFactory.Builder()
       .defaultMetaSchemaIri(SchemaId.V202012)
-      .metaSchema(schema)
+      .metaSchema(JsonMetaSchema.getV202012)
       .build()
 
     val schemaValidatorsConfig = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build()

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/JsonSchemaValidators.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/JsonSchemaValidators.scala
@@ -29,7 +29,6 @@ object JsonSchemaValidators {
 
     val schemaValidatorsConfig = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build()
 
-
     jsonSchemaFactory.getSchema(schemaInputStream, schemaValidatorsConfig)
   }
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/JsonSchemaValidators.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/JsonSchemaValidators.scala
@@ -19,16 +19,16 @@ object JsonSchemaValidators {
 
   private def getJsonSchema(jsonSchemaDefinition: JsonSchemaDefinition, customSchemaKeywords: Map[String, Keyword] = Map.empty): JsonSchema = {
     val schemaInputStream = getClass.getResourceAsStream(jsonSchemaDefinition.location)
-    val schema = JsonMetaSchema.getV7
+    val schema = JsonMetaSchema.getV202012
 
     schema.getKeywords.putAll(customSchemaKeywords.asJava)
     val jsonSchemaFactory = new JsonSchemaFactory.Builder()
-      .defaultMetaSchemaIri(SchemaId.V7)
+      .defaultMetaSchemaIri(SchemaId.V202012)
       .metaSchema(schema)
       .build()
 
-    val schemaValidatorsConfig = new SchemaValidatorsConfig()
-    schemaValidatorsConfig.setFormatAssertionsEnabled(true)
+    val schemaValidatorsConfig = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build()
+
 
     jsonSchemaFactory.getSchema(schemaInputStream, schemaValidatorsConfig)
   }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/JsonValidationErrorReason.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/JsonValidationErrorReason.scala
@@ -1,8 +1,0 @@
-package uk.gov.nationalarchives.tdr.validation.schema
-
-sealed abstract class JsonValidationErrorReason(val reason: String)
-
-object JsonValidationErrorReason {
-  final case object BASE_SCHEMA_VALIDATION extends JsonValidationErrorReason("/schema/baseSchema.schema.json")
-  final case object CLOSURE_SCHEMA_VALIDATION extends JsonValidationErrorReason("/schema/closureSchema.schema.json")
-}

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
@@ -65,8 +65,8 @@ object MetadataValidationJsonSchema {
   }
 
   private def combineErrors(errors: Seq[(String, List[ValidationError])]) = {
-    IO(errors.foldLeft(Map.empty[String, List[ValidationError]]) { case (acc, (k, v)) =>
-      acc.updated(k, acc.getOrElse(k, List.empty[ValidationError]) ++ v)
+    IO(errors.foldLeft(Map.empty[String, List[ValidationError]]) { case (idToErrorMap, (id, errors)) =>
+      idToErrorMap.updated(id, idToErrorMap.getOrElse(id, List.empty[ValidationError]) ++ errors)
     })
   }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
@@ -8,7 +8,7 @@ import uk.gov.nationalarchives.tdr.validation.schema.ValidationProcess._
 import uk.gov.nationalarchives.tdr.validation.utils.CSVtoJsonUtils
 import uk.gov.nationalarchives.tdr.validation.{FileRow, Metadata}
 
-case class ValidationError(validationProcess: ValidationProcess, property: String, errorKey: String)
+case class ValidationError(validationProcess: ValidationProcess, property: String, errorKey: String, suppliedProperty: String)
 
 object MetadataValidationJsonSchema {
 
@@ -71,7 +71,8 @@ object MetadataValidationJsonSchema {
   }
 
   private def convertValidationMessageToError(message: ValidationMessage, jsonValidationErrorReason: ValidationProcess): ValidationError = {
-    ValidationError(jsonValidationErrorReason, Option(message.getProperty).getOrElse(message.getInstanceLocation.getName(0)), message.getMessageKey)
+    val propertyName = Option(message.getProperty).getOrElse(message.getInstanceLocation.getName(0))
+    ValidationError(jsonValidationErrorReason, propertyName, message.getMessageKey, csvToJsonUtils.originalHeader(propertyName))
   }
 
   private def mapToJson: ObjectMetadata => JsonData = (data: ObjectMetadata) => {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
@@ -72,7 +72,7 @@ object MetadataValidationJsonSchema {
 
   private def convertValidationMessageToError(message: ValidationMessage, jsonValidationErrorReason: ValidationProcess): ValidationError = {
     val propertyName = Option(message.getProperty).getOrElse(message.getInstanceLocation.getName(0))
-    ValidationError(jsonValidationErrorReason, propertyName, message.getMessageKey, csvToJsonUtils.originalHeader(propertyName))
+    ValidationError(jsonValidationErrorReason, propertyName, message.getMessageKey, csvToJsonUtils.tdrFileHeader(propertyName))
   }
 
   private def mapToJson: ObjectMetadata => JsonData = (data: ObjectMetadata) => {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
@@ -71,9 +71,9 @@ object MetadataValidationJsonSchema {
     })
   }
 
-  private def convertValidationMessageToError(message: ValidationMessage, jsonValidationErrorReason: ValidationProcess): ValidationError = {
+  private def convertValidationMessageToError(message: ValidationMessage, validationProcess: ValidationProcess): ValidationError = {
     val propertyName = Option(message.getProperty).getOrElse(message.getInstanceLocation.getName(0))
-    ValidationError(jsonValidationErrorReason, propertyName, message.getMessageKey)
+    ValidationError(validationProcess, propertyName, message.getMessageKey)
   }
 
   private def mapToJson: ObjectMetadata => JsonData = (data: ObjectMetadata) => {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
@@ -4,7 +4,6 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import com.networknt.schema.ValidationMessage
-import uk.gov.nationalarchives.tdr.validation.schema.JsonSchemaDefinition.{BASE_SCHEMA, CLOSURE_SCHEMA}
 import uk.gov.nationalarchives.tdr.validation.schema.ValidationProcess._
 import uk.gov.nationalarchives.tdr.validation.utils.CSVtoJsonUtils
 import uk.gov.nationalarchives.tdr.validation.{FileRow, Metadata}
@@ -54,14 +53,8 @@ object MetadataValidationJsonSchema {
   }
 
   private def validateWithSchema(schemaDefinition: JsonSchemaDefinition): JsonData => ValidationErrorWithValidationMessages = { (jsonData: JsonData) =>
-    schemaDefinition match {
-      case BASE_SCHEMA =>
-        val errors = JsonSchemaValidators.validateJson(schemaDefinition, jsonData.json)
-        ValidationErrorWithValidationMessages(SCHEMA_BASE, jsonData.identifier, errors)
-      case CLOSURE_SCHEMA =>
-        val errors = JsonSchemaValidators.validateJson(schemaDefinition, jsonData.json)
-        ValidationErrorWithValidationMessages(SCHEMA_CLOSURE, jsonData.identifier, errors)
-    }
+    val errors = JsonSchemaValidators.validateJson(schemaDefinition, jsonData.json)
+    ValidationErrorWithValidationMessages(schemaDefinition.validationProcess, jsonData.identifier, errors)
   }
 
   /*

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
@@ -5,17 +5,17 @@ import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import com.networknt.schema.ValidationMessage
 import uk.gov.nationalarchives.tdr.validation.schema.JsonSchemaDefinition.{BASE_SCHEMA, CLOSURE_SCHEMA}
-import uk.gov.nationalarchives.tdr.validation.schema.JsonValidationErrorReason.{BASE_SCHEMA_VALIDATION, CLOSURE_SCHEMA_VALIDATION}
+import uk.gov.nationalarchives.tdr.validation.schema.ValidationProcess._
 import uk.gov.nationalarchives.tdr.validation.utils.CSVtoJsonUtils
 import uk.gov.nationalarchives.tdr.validation.{FileRow, Metadata}
 
-case class ValidationError(validationProcess: JsonValidationErrorReason, property: String, errorKey: String)
+case class ValidationError(validationProcess: ValidationProcess, property: String, errorKey: String)
 
 object MetadataValidationJsonSchema {
 
   case class ObjectMetadata(identifier: String, metadata: Set[Metadata])
 
-  private case class ValidationErrorWithValidationMessages(jsonValidationErrorReason: JsonValidationErrorReason, identifier: String, errors: Set[ValidationMessage])
+  private case class ValidationErrorWithValidationMessages(jsonValidationErrorReason: ValidationProcess, identifier: String, errors: Set[ValidationMessage])
 
   private case class JsonData(identifier: String, json: String)
 
@@ -57,10 +57,10 @@ object MetadataValidationJsonSchema {
     schemaDefinition match {
       case BASE_SCHEMA =>
         val errors = JsonSchemaValidators.validateJson(schemaDefinition, jsonData.json)
-        ValidationErrorWithValidationMessages(BASE_SCHEMA_VALIDATION, jsonData.identifier, errors)
+        ValidationErrorWithValidationMessages(SCHEMA_BASE, jsonData.identifier, errors)
       case CLOSURE_SCHEMA =>
         val errors = JsonSchemaValidators.validateJson(schemaDefinition, jsonData.json)
-        ValidationErrorWithValidationMessages(CLOSURE_SCHEMA_VALIDATION, jsonData.identifier, errors)
+        ValidationErrorWithValidationMessages(SCHEMA_CLOSURE, jsonData.identifier, errors)
     }
   }
 
@@ -77,7 +77,7 @@ object MetadataValidationJsonSchema {
     })
   }
 
-  private def convertValidationMessageToError(message: ValidationMessage, jsonValidationErrorReason: JsonValidationErrorReason): ValidationError = {
+  private def convertValidationMessageToError(message: ValidationMessage, jsonValidationErrorReason: ValidationProcess): ValidationError = {
     ValidationError(jsonValidationErrorReason, Option(message.getProperty).getOrElse(message.getInstanceLocation.getName(0)), message.getMessageKey)
   }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
@@ -47,8 +47,7 @@ object MetadataValidationJsonSchema {
       jsonData <- IO(metadata.map(objectMetadata => mapToJson(objectMetadata)))
       validationErrors <- IO(jsonData.map(jsonData => validateWithSchema(schemaDefinition)(jsonData)))
       errors <- convertSchemaValidatorError(validationErrors.toList)
-      combinedErrors <- combineErrors(errors)
-    } yield combinedErrors
+    } yield errors.toMap
 
     validationProgram.unsafeRunSync()
   }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
@@ -8,7 +8,7 @@ import uk.gov.nationalarchives.tdr.validation.schema.ValidationProcess._
 import uk.gov.nationalarchives.tdr.validation.utils.CSVtoJsonUtils
 import uk.gov.nationalarchives.tdr.validation.{FileRow, Metadata}
 
-case class ValidationError(validationProcess: ValidationProcess, property: String, errorKey: String, suppliedProperty: String)
+case class ValidationError(validationProcess: ValidationProcess, property: String, errorKey: String)
 
 object MetadataValidationJsonSchema {
 
@@ -72,7 +72,7 @@ object MetadataValidationJsonSchema {
 
   private def convertValidationMessageToError(message: ValidationMessage, jsonValidationErrorReason: ValidationProcess): ValidationError = {
     val propertyName = Option(message.getProperty).getOrElse(message.getInstanceLocation.getName(0))
-    ValidationError(jsonValidationErrorReason, propertyName, message.getMessageKey, csvToJsonUtils.tdrFileHeader(propertyName))
+    ValidationError(jsonValidationErrorReason, propertyName, message.getMessageKey)
   }
 
   private def mapToJson: ObjectMetadata => JsonData = (data: ObjectMetadata) => {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/MetadataValidationJsonSchema.scala
@@ -20,7 +20,7 @@ object MetadataValidationJsonSchema {
 
   private val csvToJsonUtils = new CSVtoJsonUtils
 
-  def validate(schema: Seq[JsonSchemaDefinition], metadata: Seq[FileRow]): Map[String, Seq[ValidationError]] = {
+  def validate(schema: Set[JsonSchemaDefinition], metadata: Seq[FileRow]): Map[String, Seq[ValidationError]] = {
     val convertedFileRows: Seq[ObjectMetadata] = metadata.map(fileRow => ObjectMetadata(fileRow.matchIdentifier, fileRow.metadata.toSet))
 
     val validationProgram = for {
@@ -33,8 +33,9 @@ object MetadataValidationJsonSchema {
     validationProgram.unsafeRunSync()
   }
 
-  private def parallelSchemaValidation(schema: Seq[JsonSchemaDefinition], jsonData: Seq[JsonData]): IO[Seq[Seq[ValidationErrorWithValidationMessages]]] = {
-    val validations: Seq[IO[Seq[ValidationErrorWithValidationMessages]]] = schema.map(schemaDefinition => IO(jsonData.map(json => validateWithSchema(schemaDefinition)(json))))
+  private def parallelSchemaValidation(schema: Set[JsonSchemaDefinition], jsonData: Seq[JsonData]): IO[Seq[Seq[ValidationErrorWithValidationMessages]]] = {
+    val validations: Seq[IO[Seq[ValidationErrorWithValidationMessages]]] =
+      schema.toSeq.map(schemaDefinition => IO(jsonData.map(json => validateWithSchema(schemaDefinition)(json))))
     validations.parSequence
   }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/ValidationProcess.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/schema/ValidationProcess.scala
@@ -1,0 +1,6 @@
+package uk.gov.nationalarchives.tdr.validation.schema
+
+object ValidationProcess extends Enumeration {
+  type ValidationProcess = Value
+  val SCHEMA_BASE, SCHEMA_CLOSURE = Value
+}

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/utils/CSVtoJsonUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/utils/CSVtoJsonUtils.scala
@@ -42,8 +42,12 @@ class CSVtoJsonUtils {
     }
   }
 
-  def originalHeader(property: String) = {
-    propertyValueConverterMap.filter(mapEntry => mapEntry._2.propertyName.equals(property)).head._1
+  def tdrFileHeader(property: String) = {
+    propertyToTRDFileHeaderMap.getOrElse(property, property)
+  }
+
+  private lazy val propertyToTRDFileHeaderMap: Map[String, String] = {
+    propertyValueConverterMap.map(mapEntry => mapEntry._2.propertyName -> mapEntry._1)
   }
 
   private val propertyValueConverterMap: Map[String, ConvertedProperty] = (for {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/utils/CSVtoJsonUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/utils/CSVtoJsonUtils.scala
@@ -42,14 +42,6 @@ class CSVtoJsonUtils {
     }
   }
 
-  def tdrFileHeader(property: String) = {
-    propertyToTRDFileHeaderMap.getOrElse(property, property)
-  }
-
-  private lazy val propertyToTRDFileHeaderMap: Map[String, String] = {
-    propertyValueConverterMap.map(mapEntry => mapEntry._2.propertyName -> mapEntry._1)
-  }
-
   private val propertyValueConverterMap: Map[String, ConvertedProperty] = (for {
     (propertyName, propertyValue) <- json("properties").obj
     propertyTypes = getPropertyType(propertyValue.obj)

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/utils/CSVtoJsonUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/utils/CSVtoJsonUtils.scala
@@ -10,7 +10,7 @@ import scala.util.Try
 class CSVtoJsonUtils {
 
   private case class ConvertedProperty(propertyName: String, convertValueFunc: String => Any)
-  private val nodeSchema = getJsonNodeFromStreamContent(getClass.getResourceAsStream(BASE_SCHEMA.location))
+  private val nodeSchema = getJsonNodeFromStreamContent(getClass.getResourceAsStream(BASE_SCHEMA.schemaLocation))
   private val json = ujson.read(nodeSchema.toPrettyString)
 
   private def getJsonNodeFromStreamContent(content: InputStream): JsonNode = {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/validation/utils/CSVtoJsonUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/validation/utils/CSVtoJsonUtils.scala
@@ -42,6 +42,10 @@ class CSVtoJsonUtils {
     }
   }
 
+  def originalHeader(property: String) = {
+    propertyValueConverterMap.filter(mapEntry => mapEntry._2.propertyName.equals(property)).head._1
+  }
+
   private val propertyValueConverterMap: Map[String, ConvertedProperty] = (for {
     (propertyName, propertyValue) <- json("properties").obj
     propertyTypes = getPropertyType(propertyValue.obj)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -16,7 +16,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Language", "Unknown")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "language", "enum", SCHEMA_BASE, "Language")
+      singleErrorCheck(validationErrors, "language", "enum", SCHEMA_BASE)
     }
     "validate correct value enumerated array" in {
       val data: Set[ObjectMetadata] = dataBuilder("Language", "Welsh")
@@ -32,7 +32,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "12-12-2012")
       val validationErrors: Map[String, List[ValidationError]] = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "date_last_modified", "format.date", SCHEMA_BASE, "Date last modified")
+      singleErrorCheck(validationErrors, "date_last_modified", "format.date", SCHEMA_BASE)
     }
     "validate correct date format" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "2023-12-05")
@@ -43,7 +43,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "date_last_modified", "type", SCHEMA_BASE, "Date last modified")
+      singleErrorCheck(validationErrors, "date_last_modified", "type", SCHEMA_BASE)
     }
     "validate end date can be empty" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date of the record", "")
@@ -54,7 +54,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Date of the record", "3000-12-12")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "end_date", "daBeforeToday", SCHEMA_BASE, "Date of the record")
+      singleErrorCheck(validationErrors, "end_date", "daBeforeToday", SCHEMA_BASE)
     }
     "validate closure period must be a number" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "123")
@@ -65,13 +65,13 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "151")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "closure_period", "maximum", SCHEMA_BASE, "Closure Period")
+      singleErrorCheck(validationErrors, "closure_period", "maximum", SCHEMA_BASE)
     }
     "validate closure period must be at least 1" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "0")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "closure_period", "minimum", SCHEMA_BASE, "Closure Period")
+      singleErrorCheck(validationErrors, "closure_period", "minimum", SCHEMA_BASE)
     }
     "validate closure period can be 150" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "150")
@@ -92,7 +92,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Is the title sensitive for the public?", "blah")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "title_closed", "unionType", SCHEMA_BASE, "Is the title sensitive for the public?")
+      singleErrorCheck(validationErrors, "title_closed", "unionType", SCHEMA_BASE)
     }
     "validate file path ok with one character" in {
       val data: Set[ObjectMetadata] = dataBuilder("Filepath", "b")
@@ -103,7 +103,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Filepath", "")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "file_path", "type", SCHEMA_BASE, "Filepath")
+      singleErrorCheck(validationErrors, "file_path", "type", SCHEMA_BASE)
     }
   }
 
@@ -134,14 +134,14 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       )
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "closure_start_date", "maxLength", SCHEMA_CLOSURE, "Closure Start Date")
+      singleErrorCheck(validationErrors, "closure_start_date", "maxLength", SCHEMA_CLOSURE)
     }
 
     "will return any error from closure schema closure_start_date has a value and no closure_type set" in {
       val data: Set[ObjectMetadata] = Set(ObjectMetadata("file1", Set(Metadata("closure_start_date", "some data"))))
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "closure_start_date", "maxLength", SCHEMA_CLOSURE, "Closure Start Date")
+      singleErrorCheck(validationErrors, "closure_start_date", "maxLength", SCHEMA_CLOSURE)
     }
 
     "not return any errors when closure_type is Closed" in {
@@ -156,12 +156,12 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "required", "Closure Start Date"),
-        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "required", "FOI exemption code"),
-        ValidationError(SCHEMA_CLOSURE, "closure_period", "required", "Closure Period"),
-        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "required", "FOI decision asserted"),
-        ValidationError(SCHEMA_CLOSURE, "description_closed", "required", "Is the description sensitive for the public?"),
-        ValidationError(SCHEMA_CLOSURE, "title_closed", "required", "Is the title sensitive for the public?")
+        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "required"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "required"),
+        ValidationError(SCHEMA_CLOSURE, "closure_period", "required"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "required"),
+        ValidationError(SCHEMA_CLOSURE, "description_closed", "required"),
+        ValidationError(SCHEMA_CLOSURE, "title_closed", "required")
       )
     }
 
@@ -170,12 +170,12 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "format.date", "Closure Start Date"),
-        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "enum", "FOI exemption code"),
-        ValidationError(SCHEMA_CLOSURE, "closure_period", "minimum", "Closure Period"),
-        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "format.date", "FOI decision asserted"),
-        ValidationError(SCHEMA_CLOSURE, "description_closed", "type", "Is the description sensitive for the public?"),
-        ValidationError(SCHEMA_CLOSURE, "title_closed", "type", "Is the title sensitive for the public?")
+        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "format.date"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "enum"),
+        ValidationError(SCHEMA_CLOSURE, "closure_period", "minimum"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "format.date"),
+        ValidationError(SCHEMA_CLOSURE, "description_closed", "type"),
+        ValidationError(SCHEMA_CLOSURE, "title_closed", "type")
       )
     }
 
@@ -184,12 +184,12 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "type", "Closure Start Date"),
-        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "type", "FOI exemption code"),
-        ValidationError(SCHEMA_CLOSURE, "closure_period", "type", "Closure Period"),
-        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "type", "FOI decision asserted"),
-        ValidationError(SCHEMA_CLOSURE, "description_closed", "type", "Is the description sensitive for the public?"),
-        ValidationError(SCHEMA_CLOSURE, "title_closed", "type", "Is the title sensitive for the public?")
+        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "type"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "type"),
+        ValidationError(SCHEMA_CLOSURE, "closure_period", "type"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "type"),
+        ValidationError(SCHEMA_CLOSURE, "description_closed", "type"),
+        ValidationError(SCHEMA_CLOSURE, "title_closed", "type")
       )
     }
   }
@@ -203,11 +203,11 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA, CLOSURE_SCHEMA), List(fileRow1, fileRow2))
       errors.size shouldBe 2
       errors("file_a").size shouldBe 2
-      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "language", "enum", "Language"))
-      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date", "Date last modified"))
+      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "language", "enum"))
+      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date"))
       errors("file_b").size shouldBe 2
-      errors("file_b") should contain(ValidationError(SCHEMA_BASE, "language", "enum", "Language"))
-      errors("file_b") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date", "Date last modified"))
+      errors("file_b") should contain(ValidationError(SCHEMA_BASE, "language", "enum"))
+      errors("file_b") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date"))
     }
 
     "validate file rows that produce error from base schema and closure" in {
@@ -217,9 +217,9 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val fileRow1 = FileRow("file_a", List(lastModified, closureStatus, closureStartDateError))
       val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA, CLOSURE_SCHEMA), List(fileRow1))
       errors.size shouldBe 1
-      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date", "Date last modified"))
-      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "closure_start_date", "format.date", "Closure Start Date"))
-      errors("file_a") should contain(ValidationError(SCHEMA_CLOSURE, "closure_start_date", "maxLength", "Closure Start Date"))
+      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date"))
+      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "closure_start_date", "format.date"))
+      errors("file_a") should contain(ValidationError(SCHEMA_CLOSURE, "closure_start_date", "maxLength"))
     }
   }
 
@@ -256,15 +256,14 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       validationErrors: Map[String, List[ValidationError]],
       propertyName: String,
       value: Any,
-      validationProcess: ValidationProcess,
-      suppliedProperty: String
+      validationProcess: ValidationProcess
   ): Unit = {
     validationErrors.foreach(objectIdentifierWithErrors =>
       objectIdentifierWithErrors._2.foreach(error => {
         error.property shouldBe propertyName
         error.errorKey shouldBe value
         error.validationProcess shouldBe validationProcess
-        error.suppliedProperty shouldBe suppliedProperty
+
       })
     )
   }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -200,7 +200,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val language = Metadata("Language", "Unknown")
       val fileRow1 = FileRow("file_a", List(lastModified, language))
       val fileRow2 = FileRow("file_b", List(lastModified, language))
-      val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA, CLOSURE_SCHEMA), List(fileRow1, fileRow2))
+      val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA, CLOSURE_SCHEMA), List(fileRow1, fileRow2))
       errors.size shouldBe 2
       errors("file_a").size shouldBe 2
       errors("file_a") should contain(ValidationError(SCHEMA_BASE, "language", "enum"))
@@ -215,7 +215,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val closureStartDateError = Metadata("Closure Start Date", "12-12-2001")
       val closureStatus = Metadata("Closure status", "Open")
       val fileRow1 = FileRow("file_a", List(lastModified, closureStatus, closureStartDateError))
-      val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA, CLOSURE_SCHEMA), List(fileRow1))
+      val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(Set(BASE_SCHEMA, CLOSURE_SCHEMA), List(fileRow1))
       errors.size shouldBe 1
       errors("file_a") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date"))
       errors("file_a") should contain(ValidationError(SCHEMA_BASE, "closure_start_date", "format.date"))

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -5,7 +5,7 @@ import org.apache.pekko.testkit.{ImplicitSender, TestKit}
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpecLike
 import uk.gov.nationalarchives.tdr.validation.schema.JsonSchemaDefinition.{BASE_SCHEMA, CLOSURE_SCHEMA}
-import uk.gov.nationalarchives.tdr.validation.schema.JsonValidationErrorReason.{BASE_SCHEMA_VALIDATION, CLOSURE_SCHEMA_VALIDATION}
+import uk.gov.nationalarchives.tdr.validation.schema.ValidationProcess.{SCHEMA_BASE, _}
 import uk.gov.nationalarchives.tdr.validation.schema.{MetadataValidationJsonSchema, ValidationError}
 import uk.gov.nationalarchives.tdr.validation.schema.MetadataValidationJsonSchema.ObjectMetadata
 
@@ -141,12 +141,12 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_start_date", "required"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "foi_exemption_code", "required"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_period", "required"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "foi_exemption_asserted", "required"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "description_closed", "required"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "title_closed", "required")
+        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "required"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "required"),
+        ValidationError(SCHEMA_CLOSURE, "closure_period", "required"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "required"),
+        ValidationError(SCHEMA_CLOSURE, "description_closed", "required"),
+        ValidationError(SCHEMA_CLOSURE, "title_closed", "required")
       )
     }
 
@@ -155,12 +155,12 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_start_date", "format.date"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "foi_exemption_code", "enum"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_period", "minimum"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "foi_exemption_asserted", "format.date"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "description_closed", "type"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "title_closed", "type")
+        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "format.date"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "enum"),
+        ValidationError(SCHEMA_CLOSURE, "closure_period", "minimum"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "format.date"),
+        ValidationError(SCHEMA_CLOSURE, "description_closed", "type"),
+        ValidationError(SCHEMA_CLOSURE, "title_closed", "type")
       )
     }
 
@@ -169,12 +169,12 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_start_date", "type"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "foi_exemption_code", "type"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_period", "type"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "foi_exemption_asserted", "type"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "description_closed", "type"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION, "title_closed", "type")
+        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "type"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "type"),
+        ValidationError(SCHEMA_CLOSURE, "closure_period", "type"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "type"),
+        ValidationError(SCHEMA_CLOSURE, "description_closed", "type"),
+        ValidationError(SCHEMA_CLOSURE, "title_closed", "type")
       )
     }
   }
@@ -197,9 +197,9 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val fileRow1 = FileRow("file_a", List(lastModified, closureStatus, closureStartDateError))
       val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA, CLOSURE_SCHEMA), List(fileRow1))
       errors.size shouldBe 1
-      errors("file_a") should contain(ValidationError(BASE_SCHEMA_VALIDATION, "date_last_modified", "format.date"))
-      errors("file_a") should contain(ValidationError(BASE_SCHEMA_VALIDATION, "closure_start_date", "format.date"))
-      errors("file_a") should contain(ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_start_date", "maxLength"))
+      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date"))
+      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "closure_start_date", "format.date"))
+      errors("file_a") should contain(ValidationError(SCHEMA_CLOSURE, "closure_start_date", "maxLength"))
     }
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -16,7 +16,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Language", "Unknown")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "language", "enum", SCHEMA_BASE)
+      singleErrorCheck(validationErrors, "language", "enum", SCHEMA_BASE, "Language")
     }
     "validate correct value enumerated array" in {
       val data: Set[ObjectMetadata] = dataBuilder("Language", "Welsh")
@@ -32,7 +32,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "12-12-2012")
       val validationErrors: Map[String, List[ValidationError]] = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "date_last_modified", "format.date", SCHEMA_BASE)
+      singleErrorCheck(validationErrors, "date_last_modified", "format.date", SCHEMA_BASE, "Date last modified")
     }
     "validate correct date format" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "2023-12-05")
@@ -43,7 +43,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "date_last_modified", "type", SCHEMA_BASE)
+      singleErrorCheck(validationErrors, "date_last_modified", "type", SCHEMA_BASE, "Date last modified")
     }
     "validate end date can be empty" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date of the record", "")
@@ -54,7 +54,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Date of the record", "3000-12-12")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "end_date", "daBeforeToday", SCHEMA_BASE)
+      singleErrorCheck(validationErrors, "end_date", "daBeforeToday", SCHEMA_BASE, "Date of the record")
     }
     "validate closure period must be a number" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "123")
@@ -65,13 +65,13 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "151")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "closure_period", "maximum", SCHEMA_BASE)
+      singleErrorCheck(validationErrors, "closure_period", "maximum", SCHEMA_BASE, "Closure Period")
     }
     "validate closure period must be at least 1" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "0")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "closure_period", "minimum", SCHEMA_BASE)
+      singleErrorCheck(validationErrors, "closure_period", "minimum", SCHEMA_BASE, "Closure Period")
     }
     "validate closure period can be 150" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "150")
@@ -92,7 +92,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Is the title sensitive for the public?", "blah")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "title_closed", "unionType", SCHEMA_BASE)
+      singleErrorCheck(validationErrors, "title_closed", "unionType", SCHEMA_BASE, "Is the title sensitive for the public?")
     }
     "validate file path ok with one character" in {
       val data: Set[ObjectMetadata] = dataBuilder("Filepath", "b")
@@ -103,7 +103,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = dataBuilder("Filepath", "")
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "file_path", "type", SCHEMA_BASE)
+      singleErrorCheck(validationErrors, "file_path", "type", SCHEMA_BASE, "Filepath")
     }
   }
 
@@ -134,14 +134,14 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       )
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "closure_start_date", "maxLength", SCHEMA_CLOSURE)
+      singleErrorCheck(validationErrors, "closure_start_date", "maxLength", SCHEMA_CLOSURE, "Closure Start Date")
     }
 
     "will return any error from closure schema closure_start_date has a value and no closure_type set" in {
       val data: Set[ObjectMetadata] = Set(ObjectMetadata("file1", Set(Metadata("closure_start_date", "some data"))))
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
-      singleErrorCheck(validationErrors, "closure_start_date", "maxLength", SCHEMA_CLOSURE)
+      singleErrorCheck(validationErrors, "closure_start_date", "maxLength", SCHEMA_CLOSURE, "Closure Start Date")
     }
 
     "not return any errors when closure_type is Closed" in {
@@ -156,12 +156,12 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "required"),
-        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "required"),
-        ValidationError(SCHEMA_CLOSURE, "closure_period", "required"),
-        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "required"),
-        ValidationError(SCHEMA_CLOSURE, "description_closed", "required"),
-        ValidationError(SCHEMA_CLOSURE, "title_closed", "required")
+        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "required", "Closure Start Date"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "required", "FOI exemption code"),
+        ValidationError(SCHEMA_CLOSURE, "closure_period", "required", "Closure Period"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "required", "FOI decision asserted"),
+        ValidationError(SCHEMA_CLOSURE, "description_closed", "required", "Is the description sensitive for the public?"),
+        ValidationError(SCHEMA_CLOSURE, "title_closed", "required", "Is the title sensitive for the public?")
       )
     }
 
@@ -170,12 +170,12 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "format.date"),
-        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "enum"),
-        ValidationError(SCHEMA_CLOSURE, "closure_period", "minimum"),
-        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "format.date"),
-        ValidationError(SCHEMA_CLOSURE, "description_closed", "type"),
-        ValidationError(SCHEMA_CLOSURE, "title_closed", "type")
+        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "format.date", "Closure Start Date"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "enum", "FOI exemption code"),
+        ValidationError(SCHEMA_CLOSURE, "closure_period", "minimum", "Closure Period"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "format.date", "FOI decision asserted"),
+        ValidationError(SCHEMA_CLOSURE, "description_closed", "type", "Is the description sensitive for the public?"),
+        ValidationError(SCHEMA_CLOSURE, "title_closed", "type", "Is the title sensitive for the public?")
       )
     }
 
@@ -184,12 +184,12 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "type"),
-        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "type"),
-        ValidationError(SCHEMA_CLOSURE, "closure_period", "type"),
-        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "type"),
-        ValidationError(SCHEMA_CLOSURE, "description_closed", "type"),
-        ValidationError(SCHEMA_CLOSURE, "title_closed", "type")
+        ValidationError(SCHEMA_CLOSURE, "closure_start_date", "type", "Closure Start Date"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_code", "type", "FOI exemption code"),
+        ValidationError(SCHEMA_CLOSURE, "closure_period", "type", "Closure Period"),
+        ValidationError(SCHEMA_CLOSURE, "foi_exemption_asserted", "type", "FOI decision asserted"),
+        ValidationError(SCHEMA_CLOSURE, "description_closed", "type", "Is the description sensitive for the public?"),
+        ValidationError(SCHEMA_CLOSURE, "title_closed", "type", "Is the title sensitive for the public?")
       )
     }
   }
@@ -203,11 +203,11 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA, CLOSURE_SCHEMA), List(fileRow1, fileRow2))
       errors.size shouldBe 2
       errors("file_a").size shouldBe 2
-      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "language", "enum"))
-      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date"))
+      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "language", "enum", "Language"))
+      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date", "Date last modified"))
       errors("file_b").size shouldBe 2
-      errors("file_b") should contain(ValidationError(SCHEMA_BASE, "language", "enum"))
-      errors("file_b") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date"))
+      errors("file_b") should contain(ValidationError(SCHEMA_BASE, "language", "enum", "Language"))
+      errors("file_b") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date", "Date last modified"))
     }
 
     "validate file rows that produce error from base schema and closure" in {
@@ -217,9 +217,9 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val fileRow1 = FileRow("file_a", List(lastModified, closureStatus, closureStartDateError))
       val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA, CLOSURE_SCHEMA), List(fileRow1))
       errors.size shouldBe 1
-      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date"))
-      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "closure_start_date", "format.date"))
-      errors("file_a") should contain(ValidationError(SCHEMA_CLOSURE, "closure_start_date", "maxLength"))
+      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "date_last_modified", "format.date", "Date last modified"))
+      errors("file_a") should contain(ValidationError(SCHEMA_BASE, "closure_start_date", "format.date", "Closure Start Date"))
+      errors("file_a") should contain(ValidationError(SCHEMA_CLOSURE, "closure_start_date", "maxLength", "Closure Start Date"))
     }
   }
 
@@ -252,12 +252,19 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
     )
   }
 
-  private def singleErrorCheck(validationErrors: Map[String, List[ValidationError]], propertyName: String, value: Any, validationProcess: ValidationProcess): Unit = {
+  private def singleErrorCheck(
+      validationErrors: Map[String, List[ValidationError]],
+      propertyName: String,
+      value: Any,
+      validationProcess: ValidationProcess,
+      suppliedProperty: String
+  ): Unit = {
     validationErrors.foreach(objectIdentifierWithErrors =>
       objectIdentifierWithErrors._2.foreach(error => {
         error.property shouldBe propertyName
         error.errorKey shouldBe value
         error.validationProcess shouldBe validationProcess
+        error.suppliedProperty shouldBe suppliedProperty
       })
     )
   }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -110,11 +110,15 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
   "MetadataValidationJsonSchema CLOSURE_SCHEMA" should {
 
     "not return any errors form Closure Schema when closure_type is Open and start date empty" in {
-      val data: Set[ObjectMetadata] = Set(ObjectMetadata("file1",
-        Set(
-          Metadata("closure_type", "Open"),
-          Metadata("closure_start_date", "")
-        )))
+      val data: Set[ObjectMetadata] = Set(
+        ObjectMetadata(
+          "file1",
+          Set(
+            Metadata("closure_type", "Open"),
+            Metadata("closure_start_date", "")
+          )
+        )
+      )
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1") shouldBe List.empty
     }
@@ -137,12 +141,12 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"closure_start_date", "required"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"foi_exemption_code", "required"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_start_date", "required"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "foi_exemption_code", "required"),
         ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_period", "required"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"foi_exemption_asserted", "required"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"description_closed", "required"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"title_closed", "required")
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "foi_exemption_asserted", "required"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "description_closed", "required"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "title_closed", "required")
       )
     }
 
@@ -151,12 +155,12 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"closure_start_date", "format.date"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"foi_exemption_code", "enum"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"closure_period", "minimum"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"foi_exemption_asserted", "format.date"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"description_closed", "type"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"title_closed", "type")
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_start_date", "format.date"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "foi_exemption_code", "enum"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_period", "minimum"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "foi_exemption_asserted", "format.date"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "description_closed", "type"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "title_closed", "type")
       )
     }
 
@@ -165,12 +169,12 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"closure_start_date", "type"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"foi_exemption_code", "type"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"closure_period", "type"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"foi_exemption_asserted", "type"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"description_closed", "type"),
-        ValidationError(CLOSURE_SCHEMA_VALIDATION,"title_closed", "type")
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_start_date", "type"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "foi_exemption_code", "type"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_period", "type"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "foi_exemption_asserted", "type"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "description_closed", "type"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "title_closed", "type")
       )
     }
   }
@@ -181,7 +185,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val language = Metadata("Language", "Unknown")
       val fileRow1 = FileRow("file_a", List(lastModified, language))
       val fileRow2 = FileRow("file_b", List(lastModified, language))
-      val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA,CLOSURE_SCHEMA),List(fileRow1, fileRow2))
+      val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA, CLOSURE_SCHEMA), List(fileRow1, fileRow2))
       errors.size shouldBe 2
       errors("file_a").size shouldBe 2
     }
@@ -189,13 +193,13 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
     "validate file rows that produce error from base schema and closure" in {
       val lastModified = Metadata("Date last modified", "12-12-2012")
       val closureStartDateError = Metadata("Closure Start Date", "12-12-2001")
-      val closureStatus = Metadata("Closure status","Open")
+      val closureStatus = Metadata("Closure status", "Open")
       val fileRow1 = FileRow("file_a", List(lastModified, closureStatus, closureStartDateError))
-      val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA,CLOSURE_SCHEMA),List(fileRow1))
+      val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA, CLOSURE_SCHEMA), List(fileRow1))
       errors.size shouldBe 1
-      errors("file_a") should contain (ValidationError(BASE_SCHEMA_VALIDATION, "date_last_modified", "format.date"))
-      errors("file_a") should contain (ValidationError(BASE_SCHEMA_VALIDATION, "closure_start_date", "format.date"))
-      errors("file_a") should contain (ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_start_date", "maxLength"))
+      errors("file_a") should contain(ValidationError(BASE_SCHEMA_VALIDATION, "date_last_modified", "format.date"))
+      errors("file_a") should contain(ValidationError(BASE_SCHEMA_VALIDATION, "closure_start_date", "format.date"))
+      errors("file_a") should contain(ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_start_date", "maxLength"))
     }
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -5,7 +5,8 @@ import org.apache.pekko.testkit.{ImplicitSender, TestKit}
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpecLike
 import uk.gov.nationalarchives.tdr.validation.schema.JsonSchemaDefinition.{BASE_SCHEMA, CLOSURE_SCHEMA}
-import uk.gov.nationalarchives.tdr.validation.schema.MetadataValidationJsonSchema
+import uk.gov.nationalarchives.tdr.validation.schema.JsonValidationErrorReason.{BASE_SCHEMA_VALIDATION, CLOSURE_SCHEMA_VALIDATION}
+import uk.gov.nationalarchives.tdr.validation.schema.{MetadataValidationJsonSchema, ValidationError}
 import uk.gov.nationalarchives.tdr.validation.schema.MetadataValidationJsonSchema.ObjectMetadata
 
 class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataValidationJsonSchemaSpec")) with ImplicitSender with AnyWordSpecLike {
@@ -13,94 +14,94 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
   "MetadataValidationJsonSchema BASIC_SCHEMA" should {
     "validate incorrect value in enumerated array" in {
       val data: Set[ObjectMetadata] = dataBuilder("Language", "Unknown")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
       singleErrorCheck(validationErrors, "language", "enum")
     }
     "validate correct value enumerated array" in {
       val data: Set[ObjectMetadata] = dataBuilder("Language", "Welsh")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 0
     }
     "validate array can be null" in {
       val data: Set[ObjectMetadata] = dataBuilder("Language", "")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 0
     }
     "validate incorrect date format" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "12-12-2012")
-      val validationErrors: Map[String, List[Error]] = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors: Map[String, List[ValidationError]] = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
       singleErrorCheck(validationErrors, "date_last_modified", "format.date")
     }
     "validate correct date format" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "2023-12-05")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 0
     }
     "validate date last modified must have a value" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date last modified", "")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
       singleErrorCheck(validationErrors, "date_last_modified", "type")
     }
     "validate end date can be empty" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date of the record", "")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 0
     }
     "validate end date must be before today" in {
       val data: Set[ObjectMetadata] = dataBuilder("Date of the record", "3000-12-12")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
       singleErrorCheck(validationErrors, "end_date", "daBeforeToday")
     }
     "validate closure period must be a number" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "123")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 0
     }
     "validate closure period must be less than 150" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "151")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
       singleErrorCheck(validationErrors, "closure_period", "maximum")
     }
     "validate closure period must be at least 1" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "0")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
       singleErrorCheck(validationErrors, "closure_period", "minimum")
     }
     "validate closure period can be 150" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "150")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 0
     }
     "validate closure period can be 1" in {
       val data: Set[ObjectMetadata] = dataBuilder("Closure Period", "1")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 0
     }
     "validate title closed is a boolean" in {
       val data: Set[ObjectMetadata] = dataBuilder("Is the title sensitive for the public?", "Yes")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 0
     }
     "validate title closed not yes/no" in {
       val data: Set[ObjectMetadata] = dataBuilder("Is the title sensitive for the public?", "blah")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
       singleErrorCheck(validationErrors, "title_closed", "unionType")
     }
     "validate file path ok with one character" in {
       val data: Set[ObjectMetadata] = dataBuilder("Filepath", "b")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 0
     }
     "validate file path must have content" in {
       val data: Set[ObjectMetadata] = dataBuilder("Filepath", "")
-      val validationErrors = MetadataValidationJsonSchema.validate(BASE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 1
       singleErrorCheck(validationErrors, "file_path", "type")
     }
@@ -108,70 +109,93 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
 
   "MetadataValidationJsonSchema CLOSURE_SCHEMA" should {
 
-    "not return any errors when closure_type is Open" in {
-      val data: Set[ObjectMetadata] = Set(ObjectMetadata("file1", Set(Metadata("closure_type", "Open"))))
-      val validationErrors = MetadataValidationJsonSchema.validate(CLOSURE_SCHEMA, data)
+    "not return any errors form Closure Schema when closure_type is Open and start date empty" in {
+      val data: Set[ObjectMetadata] = Set(ObjectMetadata("file1",
+        Set(
+          Metadata("closure_type", "Open"),
+          Metadata("closure_start_date", "")
+        )))
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1") shouldBe List.empty
+    }
+
+    "will return any errors from closure schema closure_start_date has a value and no closure_type set" in {
+      val data: Set[ObjectMetadata] = Set(ObjectMetadata("file1", Set(Metadata("closure_start_date", "some data"))))
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
+      validationErrors("file1").size shouldBe 1
     }
 
     "not return any errors when closure_type is Closed" in {
       val data: Set[ObjectMetadata] = closureDataBuilder("1990-01-12", "33", "12", "1990-11-12", "No", "No")
-      val validationErrors = MetadataValidationJsonSchema.validate(CLOSURE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1") shouldBe List.empty
     }
 
     "return errors with all the required fields when closure_type is Closed" in {
       val closure = Metadata("closure_type", "Closed")
       val data: Set[ObjectMetadata] = Set(ObjectMetadata("file1", Set(closure)))
-      val validationErrors = MetadataValidationJsonSchema.validate(CLOSURE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        Error("closure_start_date", "required"),
-        Error("foi_exemption_code", "required"),
-        Error("closure_period", "required"),
-        Error("foi_exemption_asserted", "required"),
-        Error("description_closed", "required"),
-        Error("title_closed", "required")
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"closure_start_date", "required"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"foi_exemption_code", "required"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_period", "required"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"foi_exemption_asserted", "required"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"description_closed", "required"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"title_closed", "required")
       )
     }
 
     "return errors if required fields has invalid values when closure_type is Closed" in {
       val data: Set[ObjectMetadata] = closureDataBuilder("1990--12", "55", "-12", "1990--12", "tttt", "tttt")
-      val validationErrors = MetadataValidationJsonSchema.validate(CLOSURE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        Error("closure_start_date", "format.date"),
-        Error("foi_exemption_code", "enum"),
-        Error("closure_period", "minimum"),
-        Error("foi_exemption_asserted", "format.date"),
-        Error("description_closed", "type"),
-        Error("title_closed", "type")
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"closure_start_date", "format.date"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"foi_exemption_code", "enum"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"closure_period", "minimum"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"foi_exemption_asserted", "format.date"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"description_closed", "type"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"title_closed", "type")
       )
     }
 
     "return errors if required fields have empty values when closure_type is Closed" in {
       val data: Set[ObjectMetadata] = closureDataBuilder("", "", "", "", "", "")
-      val validationErrors = MetadataValidationJsonSchema.validate(CLOSURE_SCHEMA, data)
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA, data)
       validationErrors("file1").size shouldBe 6
       validationErrors("file1") should contain theSameElementsAs List(
-        Error("closure_start_date", "type"),
-        Error("foi_exemption_code", "type"),
-        Error("closure_period", "type"),
-        Error("foi_exemption_asserted", "type"),
-        Error("description_closed", "type"),
-        Error("title_closed", "type")
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"closure_start_date", "type"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"foi_exemption_code", "type"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"closure_period", "type"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"foi_exemption_asserted", "type"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"description_closed", "type"),
+        ValidationError(CLOSURE_SCHEMA_VALIDATION,"title_closed", "type")
       )
     }
   }
 
-  "MetadataValidationJsonSchema validate List[FileRow]" should {
-    "validate file rows" in {
+  "MetadataValidationJsonSchema validate List(BASE_SCHEMA,CLOSURE_SCHEMA) List[FileRow]" should {
+    "validate file rows that only have base schema errors" in {
       val lastModified = Metadata("Date last modified", "12-12-2012")
       val language = Metadata("Language", "Unknown")
       val fileRow1 = FileRow("file_a", List(lastModified, language))
       val fileRow2 = FileRow("file_b", List(lastModified, language))
-      val errors = MetadataValidationJsonSchema.validate(List(fileRow1, fileRow2))
+      val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA,CLOSURE_SCHEMA),List(fileRow1, fileRow2))
       errors.size shouldBe 2
+      errors("file_a").size shouldBe 2
+    }
+
+    "validate file rows that produce error from base schema and closure" in {
+      val lastModified = Metadata("Date last modified", "12-12-2012")
+      val closureStartDateError = Metadata("Closure Start Date", "12-12-2001")
+      val closureStatus = Metadata("Closure status","Open")
+      val fileRow1 = FileRow("file_a", List(lastModified, closureStatus, closureStartDateError))
+      val errors: Map[String, Seq[ValidationError]] = MetadataValidationJsonSchema.validate(List(BASE_SCHEMA,CLOSURE_SCHEMA),List(fileRow1))
+      errors.size shouldBe 1
+      errors("file_a") should contain (ValidationError(BASE_SCHEMA_VALIDATION, "date_last_modified", "format.date"))
+      errors("file_a") should contain (ValidationError(BASE_SCHEMA_VALIDATION, "closure_start_date", "format.date"))
+      errors("file_a") should contain (ValidationError(CLOSURE_SCHEMA_VALIDATION, "closure_start_date", "maxLength"))
     }
   }
 
@@ -204,11 +228,11 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
     )
   }
 
-  private def singleErrorCheck(validationErrors: Map[String, List[Error]], propertyName: String, value: Any): Unit = {
+  private def singleErrorCheck(validationErrors: Map[String, List[ValidationError]], propertyName: String, value: Any): Unit = {
     validationErrors.foreach(objectIdentifierWithErrors =>
       objectIdentifierWithErrors._2.foreach(error => {
-        error.propertyName shouldBe propertyName
-        error.errorCode shouldBe value
+        error.property shouldBe propertyName
+        error.errorKey shouldBe value
       })
     )
   }


### PR DESCRIPTION
Refactor 
New interface to validate for draft metadator validator  

- allows specification of schema to use 
- new error `case class ValidationError(validationProcess: ValidationProcess, property: String, errorKey: String)`
The schema definition will include a validation process value so the error message can be built without need for match
This error can be used for JSON encoding
The property is the property name in the schema so the message properties file that will be included in the da-metadata-schema can be used.
To make the schema validation more useful I am going to add a task to create methods
`convertToValidationKey(alternateKey:String, propertyKey:String):String`
`convertToAlternateKey(alternateKey:String, propertyKey:String):String`
eg` convertToValidationKey("tdrFileHeader","Date last modified") => date_last_modified`
`convertToAlternateKey("tdrFileHeader", "date_last_modified") => Date last modified"`
 
The client will then be responsible for converting property names


