### PR TITLE
TDRD-551: title description updates

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19"
   lazy val ujson = "com.lihaoyi" % "ujson_native0.5_2.13" % "4.0.2"
   lazy val jacksonModule = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.0"
-  lazy val metadataSchema = "uk.gov.nationalarchives" % "da-metadata-schema_3" % "0.0.37"
+  lazy val metadataSchema = "uk.gov.nationalarchives" % "da-metadata-schema_3" % "0.0.40"
   lazy val jsonSchemaValidator = "com.networknt" % "json-schema-validator" % "1.5.2"
   lazy val pekkoActor = "org.apache.pekko" %% "pekko-actor-typed" % pekkoVersion
   lazy val pekkoConnectors = "org.apache.pekko" %% "pekko-connectors-csv" % pekkoVersion

--- a/validation/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/validation/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -162,7 +162,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       validationErrors("file1").size shouldBe 0
     }
 
-    "not return any errors from Closure Schema when closure_type is Open and start date empty" in {
+    "not return any errors from Closure Schema when closure_type is Open and title/desc are open and start date empty" in {
       val data: Set[ObjectMetadata] = closureDataBuilder(
         closureType = Some("Open"),
         descriptionClosed = Some("No"),
@@ -172,7 +172,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA_OPEN, data)
       validationErrors("file1") shouldBe List.empty
     }
-    "return any errors from Closure Schema when closure_type is Open and start date is not empty" in {
+    "return any errors from Closure Schema when closure_type is Open and title/desc are open and start date is not empty" in {
       val data: Set[ObjectMetadata] = closureDataBuilder(
         closureType = Some("Open"),
         descriptionClosed = Some("No"),
@@ -258,7 +258,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       validationErrors("file1").size shouldBe 0
     }
 
-    "return no errors if title/description is false and an alternative title/description is not provided when closure_type is Closed" in {
+    "return no errors if title/description closed is false and an alternative title/description is not provided when closure_type is Closed" in {
       val data: Set[ObjectMetadata] = closureDataBuilder(
         closureType = Some("Closed"),
         closureStartDate = Some("2001-12-12"),
@@ -306,7 +306,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       )
     }
 
-    "allow title/description to be null for closed" in {
+    "don't allow title/description closed to be null for closed" in {
       val data: Set[ObjectMetadata] = closureDataBuilder(
         closureType = Some("Closed"),
         closureStartDate = Some("2001-12-12"),

--- a/validation/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/validation/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -330,11 +330,10 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = closureDataBuilder(
         closureType = Some("Open"),
         titleClosed = None,
-        descriptionClosed = Some(""),
+        descriptionClosed = Some("")
       )
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA_OPEN, data)
       validationErrors("file1").size shouldBe 2
-      println( validationErrors("file1"))
       validationErrors("file1") should contain theSameElementsAs List(
         ValidationError(SCHEMA_CLOSURE_OPEN, "title_closed", "const"),
         ValidationError(SCHEMA_CLOSURE_OPEN, "description_closed", "const")
@@ -345,23 +344,21 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       val data: Set[ObjectMetadata] = closureDataBuilder(
         closureType = Some("Open"),
         titleClosed = Some("Yes"),
-        descriptionClosed = Some("Yes"),
+        descriptionClosed = Some("Yes")
       )
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA_OPEN, data)
       validationErrors("file1").size shouldBe 2
-      println( validationErrors("file1"))
       validationErrors("file1") should contain theSameElementsAs List(
         ValidationError(SCHEMA_CLOSURE_OPEN, "title_closed", "const"),
         ValidationError(SCHEMA_CLOSURE_OPEN, "description_closed", "const")
       )
     }
 
-
     "don't allow title/description closed to be null for base" in {
       val data: Set[ObjectMetadata] = closureDataBuilder(
         closureType = Some("Open"),
         titleClosed = None,
-        descriptionClosed = Some(""),
+        descriptionClosed = Some("")
       )
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
       validationErrors("file1").size shouldBe 2
@@ -381,7 +378,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
         titleClosed = Some("No"),
         titleAlternative = Some("alt title"),
         descriptionClosed = Some("No"),
-        descriptionAlternative = Some("alt desc"),
+        descriptionAlternative = Some("alt desc")
       )
       val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(CLOSURE_SCHEMA_CLOSED, data)
       validationErrors("file1").size shouldBe 2


### PR DESCRIPTION
- title closed and description closed can never be null (must be open for an open record, must be boolean for a closed record)
- if we get an alternative title or  alternative description then the title or the description must be closed