### PR TITLE
TDRD-467- Use latest schema to prevent carriage returns

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19"
   lazy val ujson = "com.lihaoyi" % "ujson_native0.5_2.13" % "4.1.0"
   lazy val jacksonModule = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.3"
-  lazy val metadataSchema = "uk.gov.nationalarchives" % "da-metadata-schema_3" % "0.0.47"
+  lazy val metadataSchema = "uk.gov.nationalarchives" % "da-metadata-schema_3" % "0.0.48"
   lazy val jsonSchemaValidator = "com.networknt" % "json-schema-validator" % "1.5.6"
   lazy val pekkoActor = "org.apache.pekko" %% "pekko-actor-typed" % pekkoVersion
   lazy val pekkoConnectors = "org.apache.pekko" %% "pekko-connectors-csv" % pekkoVersion

--- a/validation/src/test/scala/uk/gov/nationalarchives/tdr/validation/JsonSchemaValidatorsSpec.scala
+++ b/validation/src/test/scala/uk/gov/nationalarchives/tdr/validation/JsonSchemaValidatorsSpec.scala
@@ -57,7 +57,7 @@ class JsonSchemaValidatorsSpec extends AnyWordSpec with Matchers {
             be("former_reference_department") or
               be("file_name_translation") or
               be("title_alternate")
-            )
+          )
           error.getMessageKey shouldBe "pattern"
         }
       }

--- a/validation/src/test/scala/uk/gov/nationalarchives/tdr/validation/JsonSchemaValidatorsSpec.scala
+++ b/validation/src/test/scala/uk/gov/nationalarchives/tdr/validation/JsonSchemaValidatorsSpec.scala
@@ -43,6 +43,24 @@ class JsonSchemaValidatorsSpec extends AnyWordSpec with Matchers {
         val errors = JsonSchemaValidators.validateJson(BASE_SCHEMA, json)
         errors.size shouldBe 1
       }
+      "produce a pattern error for former_reference_department, file_name_translation and title_alternate if it contains linebreaks" in {
+        val json =
+          """{
+          "former_reference_department":"hello\nworld",
+          "file_name_translation":"hello\nworld",
+          "title_alternate":"hello\nworld"
+        }"""
+        val errors = JsonSchemaValidators.validateJson(BASE_SCHEMA, json)
+        errors.size shouldBe 3
+        errors.foreach { error =>
+          error.getInstanceLocation.getName(0) should (
+            be("former_reference_department") or
+              be("file_name_translation") or
+              be("title_alternate")
+            )
+          error.getMessageKey shouldBe "pattern"
+        }
+      }
       "validating using relationship schema" should {
         "produce a type error for empty description when alternate description set" in {
           val json =

--- a/validation/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/validation/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -133,6 +133,36 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       validationErrors("file1").size shouldBe 1
       singleErrorCheck(validationErrors, "former_reference_department", "maxLength", SCHEMA_BASE)
     }
+
+    "validate former_reference_department can't have line breaks'" in {
+      val data: Set[ObjectMetadata] = dataBuilder(
+        "former_reference_department",
+        "This is an example.\nwith line break"
+      )
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
+      validationErrors("file1").size shouldBe 1
+      singleErrorCheck(validationErrors, "former_reference_department", "pattern", SCHEMA_BASE)
+    }
+
+    "validate file_name_translation can't have line breaks'" in {
+      val data: Set[ObjectMetadata] = dataBuilder(
+        "file_name_translation",
+        "This is an example.\nwith line break"
+      )
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
+      validationErrors("file1").size shouldBe 1
+      singleErrorCheck(validationErrors, "file_name_translation", "pattern", SCHEMA_BASE)
+    }
+    "validate title_alternate can't have line breaks'" in {
+      val data: Set[ObjectMetadata] = dataBuilder(
+        "title_alternate",
+        "This is an example.\nwith line break"
+      )
+      val validationErrors = MetadataValidationJsonSchema.validateWithSingleSchema(BASE_SCHEMA, data)
+      validationErrors("file1").size shouldBe 1
+      singleErrorCheck(validationErrors, "title_alternate", "pattern", SCHEMA_BASE)
+    }
+
   }
 
   "MetadataValidationJsonSchema with CLOSURE_SCHEMA" should {

--- a/validation/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
+++ b/validation/src/test/scala/uk/gov/nationalarchives/tdr/validation/MetadataValidationJsonSchemaSpec.scala
@@ -134,7 +134,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       singleErrorCheck(validationErrors, "former_reference_department", "maxLength", SCHEMA_BASE)
     }
 
-    "validate former_reference_department can't have line breaks'" in {
+    "validate former_reference_department can't have line breaks" in {
       val data: Set[ObjectMetadata] = dataBuilder(
         "former_reference_department",
         "This is an example.\nwith line break"
@@ -144,7 +144,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       singleErrorCheck(validationErrors, "former_reference_department", "pattern", SCHEMA_BASE)
     }
 
-    "validate file_name_translation can't have line breaks'" in {
+    "validate file_name_translation can't have line breaks" in {
       val data: Set[ObjectMetadata] = dataBuilder(
         "file_name_translation",
         "This is an example.\nwith line break"
@@ -153,7 +153,7 @@ class MetadataValidationJsonSchemaSpec extends TestKit(ActorSystem("MetadataVali
       validationErrors("file1").size shouldBe 1
       singleErrorCheck(validationErrors, "file_name_translation", "pattern", SCHEMA_BASE)
     }
-    "validate title_alternate can't have line breaks'" in {
+    "validate title_alternate can't have line breaks" in {
       val data: Set[ObjectMetadata] = dataBuilder(
         "title_alternate",
         "This is an example.\nwith line break"


### PR DESCRIPTION
...for fields `former_reference_department` , `file_name_translation` and `title_alternative`